### PR TITLE
Deactivate eks flag only for core aws webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Deactivate eks flag only for core aws webhook
+
+
 ## [0.6.8-gs2] - 2021-08-25
 
 ### Changed

--- a/helm/cluster-api-provider-aws/templates/webhook/deployment.yaml
+++ b/helm/cluster-api-provider-aws/templates/webhook/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       - args:
         - --metrics-addr=0.0.0.0:{{ .Values.ports.metrics }}
         - --webhook-port={{ .Values.ports.webhook }}
-        - --feature-gates=EKS={{ .Values.featuregates.eks }},EKSEnableIAM={{ .Values.featuregates.eksenableiam }},MachinePool={{ .Values.featuregates.machinepool }},EventBridgeInstanceState={{ .Values.featuregates.eventbridgeinstancestate }},AutoControllerIdentityCreator={{ .Values.featuregates.autocontrolleridentitycreator }}
+        - --feature-gates=EKS=false,EKSEnableIAM={{ .Values.featuregates.eksenableiam }},MachinePool={{ .Values.featuregates.machinepool }},EventBridgeInstanceState={{ .Values.featuregates.eventbridgeinstancestate }},AutoControllerIdentityCreator={{ .Values.featuregates.autocontrolleridentitycreator }}
         image: "{{ .Values.Installation.V1.Registry.Domain }}/{{ .Values.infrastructure.image.name }}:{{ .Values.tag }}"
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
We found that if the flag is activated for the aws webhook, it can cause a connection error trying to apply EKS CRs.

### Checklist

- [ ] Update changelog in CHANGELOG.md.
