### PR TITLE
fix all labels to be unique for each pod and service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Fix labels for all deployment and services.
+
 ## [0.6.8-gs4] - 2021-09-02
 
 ### Changed

--- a/helm/cluster-api-provider-aws/templates/eks/bootstrap/eks-bootstrap-deployment-webhook.yaml
+++ b/helm/cluster-api-provider-aws/templates/eks/bootstrap/eks-bootstrap-deployment-webhook.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "labels.eks.bootstrap" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-bootstrap-webhook
   name: {{ include "resource.eksbootstrap.name" . }}-webhook
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -12,12 +12,12 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.eks.bootstrap" . | nindent 6 }}
-      control-plane: controller-manager
+      component: eks-bootstrap-webhook
   template:
     metadata:
       labels:
         {{- include "labels.eks.bootstrap" . | nindent 8 }}
-        control-plane: controller-manager
+        component: eks-bootstrap-webhook
     spec:
       containers:
       - args:

--- a/helm/cluster-api-provider-aws/templates/eks/bootstrap/eks-bootstrap-deployment.yaml
+++ b/helm/cluster-api-provider-aws/templates/eks/bootstrap/eks-bootstrap-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "labels.eks.bootstrap" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-bootstrap
   name: {{ include "resource.eksbootstrap.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -12,12 +12,12 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.eks.bootstrap" . | nindent 6 }}
-      control-plane: controller-manager
+      component: eks-bootstrap
   template:
     metadata:
       labels:
         {{- include "labels.eks.bootstrap" . | nindent 8 }}
-        control-plane: controller-manager
+        component: eks-bootstrap
     spec:
       containers:
       - args:

--- a/helm/cluster-api-provider-aws/templates/eks/bootstrap/eks-bootstrap-service-webhook.yaml
+++ b/helm/cluster-api-provider-aws/templates/eks/bootstrap/eks-bootstrap-service-webhook.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels:
     {{- include "labels.eks.bootstrap" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-bootstrap-webhook
   name: {{ include "resource.eksbootstrap.name" . }}-webhook
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -12,5 +12,6 @@ spec:
   - port: {{ .Values.ports.webhook }}
     targetPort: webhook-server
   selector:
+    component: eks-bootstrap-webhook
     {{- include "labels.eks.bootstrap" . | nindent 4 }}
 {{ end }}

--- a/helm/cluster-api-provider-aws/templates/eks/bootstrap/eks-bootstrap-service.yaml
+++ b/helm/cluster-api-provider-aws/templates/eks/bootstrap/eks-bootstrap-service.yaml
@@ -6,7 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     {{- include "labels.eks.bootstrap" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-bootstrap
   name: {{ include "resource.eksbootstrap.name" . }}-metrics
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -16,5 +16,5 @@ spec:
     targetPort: http
   selector:
     {{- include "labels.eks.bootstrap" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-bootstrap
 {{ end }}

--- a/helm/cluster-api-provider-aws/templates/eks/control-plane/eks-controlplane-deployment-webhook.yaml
+++ b/helm/cluster-api-provider-aws/templates/eks/control-plane/eks-controlplane-deployment-webhook.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "labels.eks.controlplane" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-control-plane-webhook
   name: {{ include "resource.ekscontrolplane.name" . }}-webhook
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -12,12 +12,12 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.eks.controlplane" . | nindent 6 }}
-      control-plane: controller-manager
+      component: eks-control-plane-webhook
   template:
     metadata:
       labels:
         {{- include "labels.eks.controlplane" . | nindent 8 }}
-        control-plane: controller-manager
+        component: eks-control-plane-webhook
     spec:
       containers:
       - args:

--- a/helm/cluster-api-provider-aws/templates/eks/control-plane/eks-controlplane-deployment.yaml
+++ b/helm/cluster-api-provider-aws/templates/eks/control-plane/eks-controlplane-deployment.yaml
@@ -4,7 +4,7 @@ kind: Deployment
 metadata:
   labels:
     {{- include "labels.eks.controlplane" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-control-plane
   name: {{ include "resource.ekscontrolplane.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -12,12 +12,12 @@ spec:
   selector:
     matchLabels:
       {{- include "labels.eks.controlplane" . | nindent 6 }}
-      control-plane: controller-manager
+      component: eks-control-plane
   template:
     metadata:
       labels:
         {{- include "labels.eks.controlplane" . | nindent 8 }}
-        control-plane: controller-manager
+        component: eks-control-plane
     spec:
       containers:
       - args:

--- a/helm/cluster-api-provider-aws/templates/eks/control-plane/eks-controlplane-service-webhook.yaml
+++ b/helm/cluster-api-provider-aws/templates/eks/control-plane/eks-controlplane-service-webhook.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels:
     {{- include "labels.eks.controlplane" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-control-plane-webhook
   name: {{ include "resource.ekscontrolplane.name" . }}-webhook
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -13,4 +13,5 @@ spec:
     targetPort: webhook-server
   selector:
     {{- include "labels.eks.controlplane" . | nindent 4 }}
+    component: eks-control-plane-webhook
 {{ end }}

--- a/helm/cluster-api-provider-aws/templates/eks/control-plane/eks-controlplane-service.yaml
+++ b/helm/cluster-api-provider-aws/templates/eks/control-plane/eks-controlplane-service.yaml
@@ -6,7 +6,7 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     {{- include "labels.eks.controlplane" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-control-plane
   name: {{ include "resource.ekscontrolplane.name" . }}-metrics
   namespace: {{ include "resource.default.namespace" . }}
 spec:
@@ -16,5 +16,5 @@ spec:
     targetPort: http
   selector:
     {{- include "labels.eks.controlplane" . | nindent 4 }}
-    control-plane: controller-manager
+    component: eks-control-plane
 {{ end }}

--- a/helm/cluster-api-provider-aws/templates/infrastructure-deployment.yaml
+++ b/helm/cluster-api-provider-aws/templates/infrastructure-deployment.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: capa-controller-manager
+    component: capa-controller-manager
     {{- include "labels.infrastructure" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}
   namespace: {{ include "resource.default.namespace" . }}
@@ -11,14 +11,14 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      control-plane: capa-controller-manager
+      component: capa-controller-manager
       {{- include "labels.selector" . | nindent 6 }}
   template:
     metadata:
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.arn }}:=""
       labels:
-        control-plane: capa-controller-manager
+        component: capa-controller-manager
         {{- include "labels.selector" . | nindent 8 }}
     spec:
       containers:

--- a/helm/cluster-api-provider-aws/templates/infrastructure-deployment.yaml
+++ b/helm/cluster-api-provider-aws/templates/infrastructure-deployment.yaml
@@ -12,14 +12,14 @@ spec:
   selector:
     matchLabels:
       component: capa-controller-manager
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "labels.infrastructure" . | nindent 6 }}
   template:
     metadata:
       annotations:
         iam.amazonaws.com/role: {{ .Values.aws.arn }}:=""
       labels:
         component: capa-controller-manager
-        {{- include "labels.selector" . | nindent 8 }}
+        {{- include "labels.infrastructure" . | nindent 8 }}
     spec:
       containers:
       - args:

--- a/helm/cluster-api-provider-aws/templates/infrastructure-service.yaml
+++ b/helm/cluster-api-provider-aws/templates/infrastructure-service.yaml
@@ -5,7 +5,7 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
   labels:
-    control-plane: capa-controller-manager
+    component: capa-controller-manager
     {{- include "labels.infrastructure" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}-metrics
   namespace: {{ include "resource.default.namespace" . }}
@@ -15,5 +15,6 @@ spec:
     port: {{ .Values.ports.metrics }}
     targetPort: http
   selector:
-    {{- include "labels.selector" . | nindent 4 }}
+    component: capa-controller-manager
+    {{- include "labels.infrastructure" . | nindent 4 }}
 {{ end }}

--- a/helm/cluster-api-provider-aws/templates/webhook/deployment.yaml
+++ b/helm/cluster-api-provider-aws/templates/webhook/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    control-plane: capa-controller-manager
+    component: capa-controller-manager-webhook
     {{- include "labels.infrastructure" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}-webhook
   namespace: {{ include "resource.default.namespace" . }}
@@ -10,10 +10,12 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      component: capa-controller-manager-webhook
+      {{- include "labels.infrastructure" . | nindent 6 }}
   template:
     metadata:
       labels:
+        component: capa-controller-manager-webhook
         {{- include "labels.infrastructure" . | nindent 8 }}
     spec:
       containers:

--- a/helm/cluster-api-provider-aws/templates/webhook/networkpolicy.yaml
+++ b/helm/cluster-api-provider-aws/templates/webhook/networkpolicy.yaml
@@ -9,7 +9,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      {{- include "labels.selector" . | nindent 6 }}
+      {{- include "labels.infrastructure" . | nindent 6 }}
   egress:
   - {}
   ingress:

--- a/helm/cluster-api-provider-aws/templates/webhook/service.yaml
+++ b/helm/cluster-api-provider-aws/templates/webhook/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
+    component: capa-controller-manager-webhook
     {{- include "labels.infrastructure" . | nindent 4 }}
   name: {{ include "resource.default.name" . }}-webhook
   namespace: {{ include "resource.default.namespace" . }}
@@ -10,4 +11,5 @@ spec:
   - port: {{ .Values.ports.webhook }}
     targetPort: webhook-server
   selector:
-    {{- include "labels.selector" . | nindent 4 }}
+    component: capa-controller-manager-webhook
+    {{- include "labels.infrastructure" . | nindent 4 }}


### PR DESCRIPTION
 clean the label mess that had several components using same labels for services and deployment causing that some services routed to multiple different components and also some deployment were bugged due thinking that it has running pods