### PR TITLE
Generate manifests for release 1.5.2

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -1,0 +1,10 @@
+name: verify helm manifests are up to date
+on: pull_request
+jobs:
+  make-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'checkout'
+        uses: actions/checkout@v3
+      - name: verify
+        run: make verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Generation of Helm chart will fail if we get a 404 from Github.
+
+### Fixed
+
+- Re-generate helm chart after adading feature gate.
+
 ## [1.9.0] - 2022-11-30
 
 ### Changed
 
-- Enabled external resource gc feature gate
+- Enabled external resource gc feature gate.
 
 ## [1.8.3] - 2022-11-22
 

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -20,3 +20,10 @@ $(CRD_BUILD_DIR):
 release-manifests: $(CRD_BUILD_DIR) ## Builds the manifests to publish with a release
 	# Build core-components.
 	kustomize build helm/cluster-api-provider-aws/files > $(CRD_BUILD_DIR)/crds.yaml
+
+.PHONY: verify
+verify: generate
+	@if !(git diff --quiet HEAD); then \
+		git diff; \
+		echo "generated files are out of date, run make generate"; exit 1; \
+	fi

--- a/hack/generate-kustomize-patches.sh
+++ b/hack/generate-kustomize-patches.sh
@@ -26,7 +26,7 @@ version="$(yq e '.tag' "$helm_values")"
 release_asset_filename="infrastructure-components.yaml"
 url="https://github.com/$org/$repo/releases/download/$version/$release_asset_filename"
 mkdir -p "$KUSTOMIZE_INPUT_DIR"
-curl -L "$url" -o "$KUSTOMIZE_INPUT_DIR/$release_asset_filename"
+curl --fail -L "$url" -o "$KUSTOMIZE_INPUT_DIR/$release_asset_filename"
 
 # Update kustomize patches for webhooks. We do this for every CRD
 

--- a/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
+++ b/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
@@ -44,7 +44,7 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-addr=0.0.0.0:8080
-        - --feature-gates=EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=true,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true
+        - --feature-gates=EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=true,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true,ExternalResourceGC=true
         - --watch-filter=capi
         - --v=0
         env:


### PR DESCRIPTION
We forgot to re-generate the helm chart when [we added the feature flag](https://github.com/giantswarm/cluster-api-provider-aws-app/pull/138). The generation is broken while we target our fork image, so I re-generated the helm chart using 1.5.2 from upstream.

I also
- Added `verify` github action so we don't forget to generate. It will fail until we go back to use upstream releases.
- Make `curl` to fail if it gets a 404 from Github.


### Checklist

- [X] Update changelog in CHANGELOG.md.
