### PR TITLE
Add common labels to pods so that Hubble shows the app name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add necessary values for PSS policy warnings. 
+- Add necessary values for PSS policy warnings
+- Add common labels to pods so that Hubble shows the app name
 
 ## [2.2.0] - 2023-04-19
 

--- a/config/helm/common-labels.yaml
+++ b/config/helm/common-labels.yaml
@@ -14,3 +14,6 @@ labels:
 fieldSpecs:
   - path: metadata/labels
     create: true
+  - path: spec/template/metadata/labels
+    create: true
+    kind: Deployment

--- a/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
+++ b/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
@@ -24,8 +24,15 @@ spec:
       annotations:
         iam.amazonaws.com/role: '{{ .Values.aws.arn }}:=""'
       labels:
+        app.giantswarm.io/branch: '{{ .Values.project.branch }}'
+        app.giantswarm.io/commit: '{{ .Values.project.commit }}'
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
+        app.kubernetes.io/managed-by: '{{ .Release.Service }}'
+        app.kubernetes.io/name: '{{ .Chart.Name }}'
+        app.kubernetes.io/version: '{{ .Chart.AppVersion }}'
         cluster.x-k8s.io/provider: infrastructure-aws
         control-plane: capa-controller-manager
+        helm.sh/chart: '{{ .Chart.Name }}'
     spec:
       affinity:
         nodeAffinity:


### PR DESCRIPTION
Hubble would otherwise show "Unknown app" for the flow diagram. Part of https://github.com/giantswarm/giantswarm/issues/27266.

### Checklist

- [x] Update changelog in CHANGELOG.md.
