### PR TITLE
Upgrade to cluster-api-provider-aws v2.2.1 + hotfix, switch to using Giant Swarm cluster-api-provider-aws fork's GitHub releases to make things consistent with the cluster-api fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade to cluster-api-provider-aws v2.2.1
+- Switch to using Giant Swarm cluster-api-provider-aws fork's GitHub releases to make things consistent with the cluster-api fork
+
 ## [2.3.0] - 2023-07-14
 
 ### Fixed

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -7,15 +7,7 @@ resources:
   - input/infrastructure-components.yaml
 
 images:
-  - name: k8s.gcr.io/cluster-api-aws/cluster-api-aws-controller
-    newName: "{{.Values.infrastructure.image.domain}}/{{ .Values.infrastructure.image.name}}"
-    newTag: "{{.Values.tag}}"
   - name: registry.k8s.io/cluster-api-aws/cluster-api-aws-controller
-    newName: "{{.Values.infrastructure.image.domain}}/{{.Values.infrastructure.image.name}}"
-    newTag: "{{.Values.tag}}"
-
-  # See https://github.com/giantswarm/cluster-api-provider-aws/blob/main/.circleci/config.yml
-  - name: REPLACE_ME_REGISTRY/cluster-api-aws-controller
     newName: "{{.Values.infrastructure.image.domain}}/{{.Values.infrastructure.image.name}}"
     newTag: "{{.Values.tag}}"
 

--- a/config/helm/webhook-validating-watchfilter.yaml
+++ b/config/helm/webhook-validating-watchfilter.yaml
@@ -28,6 +28,10 @@ webhooks:
     objectSelector:
       matchLabels:
         cluster.x-k8s.io/watch-filter: capi
+  - name: validation.awsmachinetemplate.infrastructure.cluster.x-k8s.io
+    objectSelector:
+      matchLabels:
+        cluster.x-k8s.io/watch-filter: capi
   - name: validation.awsfargateprofile.infrastructure.cluster.x-k8s.io
     objectSelector:
       matchLabels:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -25,6 +25,9 @@
               items:
                 description: Addon represents a EKS addon.
                 properties:
+                  configuration:
+                    description: Configuration of the EKS addon
+                    type: string
                   conflictResolution:
                     default: none
                     description: ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none
@@ -304,8 +307,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
+                    required:
+                      - id
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:
@@ -567,7 +575,7 @@
                         description: The machine address.
                         type: string
                       type:
-                        description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                        description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
                         type: string
                     required:
                       - address
@@ -591,6 +599,38 @@
                 imageId:
                   description: The ID of the AMI used to launch the instance.
                   type: string
+                instanceMetadataOptions:
+                  description: InstanceMetadataOptions is the metadata options for the EC2 instance.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1"
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: optional
+                      description: "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: optional"
+                      enum:
+                        - optional
+                        - required
+                      type: string
+                    instanceMetadataTags:
+                      default: disabled
+                      description: "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                  type: object
                 instanceState:
                   description: The current state of the instance.
                   type: string
@@ -633,6 +673,9 @@
                       - size
                     type: object
                   type: array
+                placementGroupName:
+                  description: PlacementGroupName specifies the name of the placement group in which to launch the instance.
+                  type: string
                 privateIp:
                   description: The private IPv4 address assigned to the instance.
                   type: string
@@ -834,7 +877,10 @@
                                 enum:
                                   - tcp
                                   - tls
-                                  - upd
+                                  - udp
+                                  - TCP
+                                  - TLS
+                                  - UDP
                                 type: string
                               targetGroupHealthCheck:
                                 description: HealthCheck is the elb health check associated with the load balancer.
@@ -967,8 +1013,10 @@
                                 type: string
                               type: array
                             description:
+                              description: Description provides extended information about the ingress rule.
                               type: string
                             fromPort:
+                              description: FromPort is the start of port range.
                               format: int64
                               type: integer
                             ipv6CidrBlocks:
@@ -977,14 +1025,35 @@
                                 type: string
                               type: array
                             protocol:
-                              description: SecurityGroupProtocol defines the protocol type for a security group rule.
+                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                              enum:
+                                - "-1"
+                                - "4"
+                                - tcp
+                                - udp
+                                - icmp
+                                - "58"
                               type: string
                             sourceSecurityGroupIds:
                               description: The security group id to allow access from. Cannot be specified with CidrBlocks.
                               items:
                                 type: string
                               type: array
+                            sourceSecurityGroupRoles:
+                              description: The security group role to allow access from. Cannot be specified with CidrBlocks. The field will be combined with source security group IDs if specified.
+                              items:
+                                description: SecurityGroupRole defines the unique role of a security group.
+                                enum:
+                                  - bastion
+                                  - node
+                                  - controlplane
+                                  - apiserver-lb
+                                  - lb
+                                  - node-eks-additional
+                                type: string
+                              type: array
                             toPort:
+                              description: ToPort is the end of port range.
                               format: int64
                               type: integer
                           required:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -307,13 +307,8 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    required:
-                      - id
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                    - id
-                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -303,13 +303,8 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    required:
-                      - id
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                    - id
-                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -25,6 +25,9 @@
               items:
                 description: Addon represents a EKS addon.
                 properties:
+                  configuration:
+                    description: Configuration of the EKS addon
+                    type: string
                   conflictResolution:
                     default: overwrite
                     description: ConflictResolution is used to declare what should happen if there are parameter conflicts. Defaults to none
@@ -300,8 +303,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
+                    required:
+                      - id
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:
@@ -381,6 +389,9 @@
                   description: The prefix that is prepended to username claims to prevent clashes with existing names. If you do not provide this field, and username is a value other than email, the prefix defaults to issuerurl#. You can use the value - to disable all prefixing.
                   type: string
               type: object
+            partition:
+              description: Partition is the AWS security partition being used. Defaults to "aws"
+              type: string
             region:
               description: The AWS Region the cluster lives in.
               type: string
@@ -567,7 +578,7 @@
                         description: The machine address.
                         type: string
                       type:
-                        description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                        description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
                         type: string
                     required:
                       - address
@@ -591,6 +602,38 @@
                 imageId:
                   description: The ID of the AMI used to launch the instance.
                   type: string
+                instanceMetadataOptions:
+                  description: InstanceMetadataOptions is the metadata options for the EC2 instance.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1"
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: optional
+                      description: "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: optional"
+                      enum:
+                        - optional
+                        - required
+                      type: string
+                    instanceMetadataTags:
+                      default: disabled
+                      description: "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                  type: object
                 instanceState:
                   description: The current state of the instance.
                   type: string
@@ -633,6 +676,9 @@
                       - size
                     type: object
                   type: array
+                placementGroupName:
+                  description: PlacementGroupName specifies the name of the placement group in which to launch the instance.
+                  type: string
                 privateIp:
                   description: The private IPv4 address assigned to the instance.
                   type: string
@@ -834,7 +880,10 @@
                                 enum:
                                   - tcp
                                   - tls
-                                  - upd
+                                  - udp
+                                  - TCP
+                                  - TLS
+                                  - UDP
                                 type: string
                               targetGroupHealthCheck:
                                 description: HealthCheck is the elb health check associated with the load balancer.
@@ -967,8 +1016,10 @@
                                 type: string
                               type: array
                             description:
+                              description: Description provides extended information about the ingress rule.
                               type: string
                             fromPort:
+                              description: FromPort is the start of port range.
                               format: int64
                               type: integer
                             ipv6CidrBlocks:
@@ -977,14 +1028,35 @@
                                 type: string
                               type: array
                             protocol:
-                              description: SecurityGroupProtocol defines the protocol type for a security group rule.
+                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                              enum:
+                                - "-1"
+                                - "4"
+                                - tcp
+                                - udp
+                                - icmp
+                                - "58"
                               type: string
                             sourceSecurityGroupIds:
                               description: The security group id to allow access from. Cannot be specified with CidrBlocks.
                               items:
                                 type: string
                               type: array
+                            sourceSecurityGroupRoles:
+                              description: The security group role to allow access from. Cannot be specified with CidrBlocks. The field will be combined with source security group IDs if specified.
+                              items:
+                                description: SecurityGroupRole defines the unique role of a security group.
+                                enum:
+                                  - bastion
+                                  - node
+                                  - controlplane
+                                  - apiserver-lb
+                                  - lb
+                                  - node-eks-additional
+                                type: string
+                              type: array
                             toPort:
+                              description: ToPort is the end of port range.
                               format: int64
                               type: integer
                           required:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta1/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta1/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -273,7 +273,7 @@
                         description: The machine address.
                         type: string
                       type:
-                        description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                        description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
                         type: string
                     required:
                       - address

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta1/awsmachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta1/awsmachines.infrastructure.cluster.x-k8s.io.yaml
@@ -256,7 +256,7 @@
                     description: The machine address.
                     type: string
                   type:
-                    description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                    description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
                     type: string
                 required:
                   - address

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -71,7 +71,75 @@
                   type: boolean
                 healthCheckProtocol:
                   description: HealthCheckProtocol sets the protocol type for ELB health check target default value is ELBProtocolSSL
+                  enum:
+                    - TCP
+                    - SSL
+                    - HTTP
+                    - HTTPS
+                    - TLS
+                    - UDP
                   type: string
+                ingressRules:
+                  description: IngressRules sets the ingress rules for the control plane load balancer.
+                  items:
+                    description: IngressRule defines an AWS ingress rule for security groups.
+                    properties:
+                      cidrBlocks:
+                        description: List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.
+                        items:
+                          type: string
+                        type: array
+                      description:
+                        description: Description provides extended information about the ingress rule.
+                        type: string
+                      fromPort:
+                        description: FromPort is the start of port range.
+                        format: int64
+                        type: integer
+                      ipv6CidrBlocks:
+                        description: List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.
+                        items:
+                          type: string
+                        type: array
+                      protocol:
+                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                        enum:
+                          - "-1"
+                          - "4"
+                          - tcp
+                          - udp
+                          - icmp
+                          - "58"
+                        type: string
+                      sourceSecurityGroupIds:
+                        description: The security group id to allow access from. Cannot be specified with CidrBlocks.
+                        items:
+                          type: string
+                        type: array
+                      sourceSecurityGroupRoles:
+                        description: The security group role to allow access from. Cannot be specified with CidrBlocks. The field will be combined with source security group IDs if specified.
+                        items:
+                          description: SecurityGroupRole defines the unique role of a security group.
+                          enum:
+                            - bastion
+                            - node
+                            - controlplane
+                            - apiserver-lb
+                            - lb
+                            - node-eks-additional
+                          type: string
+                        type: array
+                      toPort:
+                        description: ToPort is the end of port range.
+                        format: int64
+                        type: integer
+                    required:
+                      - description
+                      - fromPort
+                      - protocol
+                      - toPort
+                    type: object
+                  type: array
                 loadBalancerType:
                   default: classic
                   description: LoadBalancerType sets the type for a load balancer. The default type is classic.
@@ -198,8 +266,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
+                    required:
+                      - id
                     type: object
                   type: array
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:
@@ -244,6 +317,9 @@
                       type: object
                   type: object
               type: object
+            partition:
+              description: Partition is the AWS security partition being used. Defaults to "aws"
+              type: string
             region:
               description: The AWS Region the cluster lives in.
               type: string
@@ -288,7 +364,7 @@
                         description: The machine address.
                         type: string
                       type:
-                        description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                        description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
                         type: string
                     required:
                       - address
@@ -312,6 +388,38 @@
                 imageId:
                   description: The ID of the AMI used to launch the instance.
                   type: string
+                instanceMetadataOptions:
+                  description: InstanceMetadataOptions is the metadata options for the EC2 instance.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1"
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: optional
+                      description: "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: optional"
+                      enum:
+                        - optional
+                        - required
+                      type: string
+                    instanceMetadataTags:
+                      default: disabled
+                      description: "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                  type: object
                 instanceState:
                   description: The current state of the instance.
                   type: string
@@ -354,6 +462,9 @@
                       - size
                     type: object
                   type: array
+                placementGroupName:
+                  description: PlacementGroupName specifies the name of the placement group in which to launch the instance.
+                  type: string
                 privateIp:
                   description: The private IPv4 address assigned to the instance.
                   type: string
@@ -535,7 +646,10 @@
                                 enum:
                                   - tcp
                                   - tls
-                                  - upd
+                                  - udp
+                                  - TCP
+                                  - TLS
+                                  - UDP
                                 type: string
                               targetGroupHealthCheck:
                                 description: HealthCheck is the elb health check associated with the load balancer.
@@ -668,8 +782,10 @@
                                 type: string
                               type: array
                             description:
+                              description: Description provides extended information about the ingress rule.
                               type: string
                             fromPort:
+                              description: FromPort is the start of port range.
                               format: int64
                               type: integer
                             ipv6CidrBlocks:
@@ -678,14 +794,35 @@
                                 type: string
                               type: array
                             protocol:
-                              description: SecurityGroupProtocol defines the protocol type for a security group rule.
+                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                              enum:
+                                - "-1"
+                                - "4"
+                                - tcp
+                                - udp
+                                - icmp
+                                - "58"
                               type: string
                             sourceSecurityGroupIds:
                               description: The security group id to allow access from. Cannot be specified with CidrBlocks.
                               items:
                                 type: string
                               type: array
+                            sourceSecurityGroupRoles:
+                              description: The security group role to allow access from. Cannot be specified with CidrBlocks. The field will be combined with source security group IDs if specified.
+                              items:
+                                description: SecurityGroupRole defines the unique role of a security group.
+                                enum:
+                                  - bastion
+                                  - node
+                                  - controlplane
+                                  - apiserver-lb
+                                  - lb
+                                  - node-eks-additional
+                                type: string
+                              type: array
                             toPort:
+                              description: ToPort is the end of port range.
                               format: int64
                               type: integer
                           required:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -266,13 +266,8 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    required:
-                      - id
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                    - id
-                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -285,13 +285,8 @@
                                   type: string
                                 description: Tags is a collection of tags describing the resource.
                                 type: object
-                            required:
-                              - id
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                            - id
-                          x-kubernetes-list-type: map
                         vpc:
                           description: VPC configuration.
                           properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -90,7 +90,75 @@
                           type: boolean
                         healthCheckProtocol:
                           description: HealthCheckProtocol sets the protocol type for ELB health check target default value is ELBProtocolSSL
+                          enum:
+                            - TCP
+                            - SSL
+                            - HTTP
+                            - HTTPS
+                            - TLS
+                            - UDP
                           type: string
+                        ingressRules:
+                          description: IngressRules sets the ingress rules for the control plane load balancer.
+                          items:
+                            description: IngressRule defines an AWS ingress rule for security groups.
+                            properties:
+                              cidrBlocks:
+                                description: List of CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              description:
+                                description: Description provides extended information about the ingress rule.
+                                type: string
+                              fromPort:
+                                description: FromPort is the start of port range.
+                                format: int64
+                                type: integer
+                              ipv6CidrBlocks:
+                                description: List of IPv6 CIDR blocks to allow access from. Cannot be specified with SourceSecurityGroupID.
+                                items:
+                                  type: string
+                                type: array
+                              protocol:
+                                description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                                enum:
+                                  - "-1"
+                                  - "4"
+                                  - tcp
+                                  - udp
+                                  - icmp
+                                  - "58"
+                                type: string
+                              sourceSecurityGroupIds:
+                                description: The security group id to allow access from. Cannot be specified with CidrBlocks.
+                                items:
+                                  type: string
+                                type: array
+                              sourceSecurityGroupRoles:
+                                description: The security group role to allow access from. Cannot be specified with CidrBlocks. The field will be combined with source security group IDs if specified.
+                                items:
+                                  description: SecurityGroupRole defines the unique role of a security group.
+                                  enum:
+                                    - bastion
+                                    - node
+                                    - controlplane
+                                    - apiserver-lb
+                                    - lb
+                                    - node-eks-additional
+                                  type: string
+                                type: array
+                              toPort:
+                                description: ToPort is the end of port range.
+                                format: int64
+                                type: integer
+                            required:
+                              - description
+                              - fromPort
+                              - protocol
+                              - toPort
+                            type: object
+                          type: array
                         loadBalancerType:
                           default: classic
                           description: LoadBalancerType sets the type for a load balancer. The default type is classic.
@@ -217,8 +285,13 @@
                                   type: string
                                 description: Tags is a collection of tags describing the resource.
                                 type: object
+                            required:
+                              - id
                             type: object
                           type: array
+                          x-kubernetes-list-map-keys:
+                            - id
+                          x-kubernetes-list-type: map
                         vpc:
                           description: VPC configuration.
                           properties:
@@ -263,6 +336,9 @@
                               type: object
                           type: object
                       type: object
+                    partition:
+                      description: Partition is the AWS security partition being used. Defaults to "aws"
+                      type: string
                     region:
                       description: The AWS Region the cluster lives in.
                       type: string

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachines.infrastructure.cluster.x-k8s.io.yaml
@@ -106,6 +106,38 @@
             instanceID:
               description: InstanceID is the EC2 instance ID for this machine.
               type: string
+            instanceMetadataOptions:
+              description: InstanceMetadataOptions is the metadata options for the EC2 instance.
+              properties:
+                httpEndpoint:
+                  default: enabled
+                  description: "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled"
+                  enum:
+                    - enabled
+                    - disabled
+                  type: string
+                httpPutResponseHopLimit:
+                  default: 1
+                  description: "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1"
+                  format: int64
+                  maximum: 64
+                  minimum: 1
+                  type: integer
+                httpTokens:
+                  default: optional
+                  description: "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: optional"
+                  enum:
+                    - optional
+                    - required
+                  type: string
+                instanceMetadataTags:
+                  default: disabled
+                  description: "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled"
+                  enum:
+                    - enabled
+                    - disabled
+                  type: string
+              type: object
             instanceType:
               description: 'InstanceType is the type of instance to create. Example: m4.xlarge'
               minLength: 2
@@ -150,6 +182,9 @@
                   - size
                 type: object
               type: array
+            placementGroupName:
+              description: PlacementGroupName specifies the name of the placement group in which to launch the instance.
+              type: string
             providerID:
               description: ProviderID is the unique identifier as specified by the cloud provider.
               type: string
@@ -247,7 +282,7 @@
                     description: The machine address.
                     type: string
                   type:
-                    description: Machine address type, one of Hostname, ExternalIP or InternalIP.
+                    description: Machine address type, one of Hostname, ExternalIP, InternalIP, ExternalDNS or InternalDNS.
                     type: string
                 required:
                   - address

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -126,6 +126,38 @@
                     instanceID:
                       description: InstanceID is the EC2 instance ID for this machine.
                       type: string
+                    instanceMetadataOptions:
+                      description: InstanceMetadataOptions is the metadata options for the EC2 instance.
+                      properties:
+                        httpEndpoint:
+                          default: enabled
+                          description: "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled"
+                          enum:
+                            - enabled
+                            - disabled
+                          type: string
+                        httpPutResponseHopLimit:
+                          default: 1
+                          description: "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1"
+                          format: int64
+                          maximum: 64
+                          minimum: 1
+                          type: integer
+                        httpTokens:
+                          default: optional
+                          description: "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: optional"
+                          enum:
+                            - optional
+                            - required
+                          type: string
+                        instanceMetadataTags:
+                          default: disabled
+                          description: "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled"
+                          enum:
+                            - enabled
+                            - disabled
+                          type: string
+                      type: object
                     instanceType:
                       description: 'InstanceType is the type of instance to create. Example: m4.xlarge'
                       minLength: 2
@@ -170,6 +202,9 @@
                           - size
                         type: object
                       type: array
+                    placementGroupName:
+                      description: PlacementGroupName specifies the name of the placement group in which to launch the instance.
+                      type: string
                     providerID:
                       description: ProviderID is the unique identifier as specified by the cloud provider.
                       type: string

--- a/helm/cluster-api-provider-aws/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capa-validating-webhook-configuration.yaml
+++ b/helm/cluster-api-provider-aws/templates/admissionregistration.k8s.io_v1_validatingwebhookconfiguration_capa-validating-webhook-configuration.yaml
@@ -171,6 +171,31 @@ webhooks:
     service:
       name: capa-webhook-service
       namespace: '{{ .Release.Namespace }}'
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsmachinetemplate
+  failurePolicy: Fail
+  matchPolicy: Equivalent
+  name: validation.awsmachinetemplate.infrastructure.cluster.x-k8s.io
+  objectSelector:
+    matchLabels:
+      cluster.x-k8s.io/watch-filter: capi
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - awsmachinetemplates
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: capa-webhook-service
+      namespace: '{{ .Release.Namespace }}'
       path: /validate-infrastructure-cluster-x-k8s-io-v1beta2-awsfargateprofile
   failurePolicy: Fail
   matchPolicy: Equivalent

--- a/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
+++ b/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
@@ -85,6 +85,8 @@ spec:
           capabilities:
             drop:
             - ALL
+          runAsGroup: 65532
+          runAsUser: 65532
           seccompProfile:
             type: RuntimeDefault
         volumeMounts:

--- a/helm/cluster-api-provider-aws/templates/rbac.authorization.k8s.io_v1_clusterrole_capa-manager-role.yaml
+++ b/helm/cluster-api-provider-aws/templates/rbac.authorization.k8s.io_v1_clusterrole_capa-manager-role.yaml
@@ -84,6 +84,14 @@ rules:
 - apiGroups:
   - cluster.x-k8s.io
   resources:
+  - machinedeployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
   - machinepools
   verbs:
   - get
@@ -268,6 +276,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsmachinetemplates
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io
   resources:

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -4,7 +4,7 @@ name: cluster-api-provider-aws
 # This value can also be a commit (even works for `make generate`), but tags are preferred since those can include a
 # message and tell us explicitly that the commit is important. Please include the short commit SHA in the tag name,
 # such as `v2.0.2-gs-123abcd`.
-tag: v2.0.2-gs-3ac448ce2
+tag: v2.2.1-gs-277133793
 
 infrastructure:
   image:

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -1,10 +1,8 @@
 name: cluster-api-provider-aws
-# Latest upstream release v2.0.2 does not have our `infrav1.LoadBalancerReadyCondition` patch
-# (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3871), so we use a newer version than v2.0.2.
 # This value can also be a commit (even works for `make generate`), but tags are preferred since those can include a
 # message and tell us explicitly that the commit is important. Please include the short commit SHA in the tag name,
 # such as `v2.0.2-gs-123abcd`.
-tag: v2.2.1-gs-277133793
+tag: v2.2.1-gs-a8b6068a0  # upstream v2.2.1 + workaround for long-lasting broken subnets issue (https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4026)
 
 infrastructure:
   image:


### PR DESCRIPTION
Uses CAPA v2.2.1 + hotfix https://github.com/giantswarm/cluster-api-provider-aws/pull/543 (which must be merged first so the `tag:` value is correct in _this_ PR), and also switches to reading manifests from GitHub releases which we now consistently want to do in the CAPI and CAPA forks.

### Checklist

- [x] Update changelog in CHANGELOG.md.
