### PR TITLE
Bump to CAPA version with the backported feature "Tag S3 bucket as owned by cluster"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `global.podSecurityStandards.enforced` value for PSS migration.
+- Bump to CAPA version with the backported feature "Tag S3 bucket as owned by cluster"
 
 ## [2.5.0] - 2023-10-09
 

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -2,7 +2,7 @@ name: cluster-api-provider-aws
 # This value can also be a commit (even works for `make generate`), but tags are preferred since those can include a
 # message and tell us explicitly that the commit is important. Please include the short commit SHA in the tag name,
 # such as `v2.0.2-gs-123abcd`.
-tag: v2.2.4-gs-6532e7d3a  # upstream v2.2.4 + workaround for long-lasting broken subnets issue (https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4026)
+tag: v2.2.4-gs-c9e3abe9f  # upstream v2.2.4 + workaround for long-lasting broken subnets issue (https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4026) + S3 bucket tagging
 
 infrastructure:
   image:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2929

### Checklist

- [x] Update changelog in CHANGELOG.md.
