### PR TITLE
Upgrade CAPA to v2.3.0 but comment out CRD upgrade so existing clusters reconcile fine without having the newly-required subent `id` field yet

### DIFF
--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -264,7 +264,7 @@
                           type: string
                         type: array
                       protocol:
-                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                         enum:
                           - "-1"
                           - "4"
@@ -272,6 +272,7 @@
                           - udp
                           - icmp
                           - "58"
+                          - "50"
                         type: string
                       sourceSecurityGroupIds:
                         description: The security group id to allow access from. Cannot be specified with CidrBlocks.
@@ -346,7 +347,7 @@
                         description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC.
                         type: string
                       id:
-                        description: ID defines a unique identifier to reference this resource.
+                        description: "ID defines a unique identifier to reference this resource. If you're bringing your subnet, set the AWS subnet-id here, it must start with `subnet-`. \n When the VPC is managed by CAPA, and you'd like the provider to create a subnet for you, the id can be set to any placeholder value that does not start with `subnet-`; upon creation, the subnet AWS identifier will be populated in the `ResourceID` field and the `id` field is going to be used as the subnet name. If you specify a tag called `Name`, it takes precedence."
                         type: string
                       ipv6CidrBlock:
                         description: IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
@@ -360,6 +361,9 @@
                       natGatewayId:
                         description: NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.
                         type: string
+                      resourceID:
+                        description: ResourceID is the subnet identifier from AWS, READ ONLY. This field is populated when the provider manages the subnet.
+                        type: string
                       routeTableId:
                         description: RouteTableID is the routing table id associated with the subnet.
                         type: string
@@ -368,8 +372,19 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
+                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                    # ---
+                    # required:
+                    #   - id
                     type: object
                   type: array
+                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                  # ---
+                  # x-kubernetes-list-map-keys:
+                  #   - id
+                  # x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:
@@ -386,7 +401,7 @@
                       minimum: 1
                       type: integer
                     cidrBlock:
-                      description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                      description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16. Mutually exclusive with IPAMPool.
                       type: string
                     id:
                       description: ID is the vpc-id of the VPC this provider should use to create resources.
@@ -394,17 +409,45 @@
                     internetGatewayId:
                       description: InternetGatewayID is the id of the internet gateway associated with the VPC.
                       type: string
+                    ipamPool:
+                      description: IPAMPool defines the IPAMv4 pool to be used for VPC. Mutually exclusive with CidrBlock.
+                      properties:
+                        id:
+                          description: ID is the ID of the IPAM pool this provider should use to create VPC.
+                          type: string
+                        name:
+                          description: Name is the name of the IPAM pool this provider should use to create VPC.
+                          type: string
+                        netmaskLength:
+                          description: The netmask length of the IPv4 CIDR you want to allocate to VPC from an Amazon VPC IP Address Manager (IPAM) pool. Defaults to /16 for IPv4 if not specified.
+                          format: int64
+                          type: integer
+                      type: object
                     ipv6:
                       description: IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.
                       properties:
                         cidrBlock:
-                          description: CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.
+                          description: CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6. Mutually exclusive with IPAMPool.
                           type: string
                         egressOnlyInternetGatewayId:
                           description: EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.
                           type: string
+                        ipamPool:
+                          description: IPAMPool defines the IPAMv6 pool to be used for VPC. Mutually exclusive with CidrBlock.
+                          properties:
+                            id:
+                              description: ID is the ID of the IPAM pool this provider should use to create VPC.
+                              type: string
+                            name:
+                              description: Name is the name of the IPAM pool this provider should use to create VPC.
+                              type: string
+                            netmaskLength:
+                              description: The netmask length of the IPv4 CIDR you want to allocate to VPC from an Amazon VPC IP Address Manager (IPAM) pool. Defaults to /16 for IPv4 if not specified.
+                              format: int64
+                              type: integer
+                          type: object
                         poolId:
-                          description: PoolID is the IP pool which must be defined in case of BYO IP is defined.
+                          description: PoolID is the IP pool which must be defined in case of BYO IP is defined. Must be specified if CidrBlock is set. Mutually exclusive with IPAMPool.
                           type: string
                       type: object
                     tags:
@@ -1090,7 +1133,7 @@
                                 type: string
                               type: array
                             protocol:
-                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                               enum:
                                 - "-1"
                                 - "4"
@@ -1098,6 +1141,7 @@
                                 - udp
                                 - icmp
                                 - "58"
+                                - "50"
                               type: string
                             sourceSecurityGroupIds:
                               description: The security group id to allow access from. Cannot be specified with CidrBlocks.

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -260,7 +260,7 @@
                           type: string
                         type: array
                       protocol:
-                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                         enum:
                           - "-1"
                           - "4"
@@ -268,6 +268,7 @@
                           - udp
                           - icmp
                           - "58"
+                          - "50"
                         type: string
                       sourceSecurityGroupIds:
                         description: The security group id to allow access from. Cannot be specified with CidrBlocks.
@@ -342,7 +343,7 @@
                         description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC.
                         type: string
                       id:
-                        description: ID defines a unique identifier to reference this resource.
+                        description: "ID defines a unique identifier to reference this resource. If you're bringing your subnet, set the AWS subnet-id here, it must start with `subnet-`. \n When the VPC is managed by CAPA, and you'd like the provider to create a subnet for you, the id can be set to any placeholder value that does not start with `subnet-`; upon creation, the subnet AWS identifier will be populated in the `ResourceID` field and the `id` field is going to be used as the subnet name. If you specify a tag called `Name`, it takes precedence."
                         type: string
                       ipv6CidrBlock:
                         description: IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
@@ -356,6 +357,9 @@
                       natGatewayId:
                         description: NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.
                         type: string
+                      resourceID:
+                        description: ResourceID is the subnet identifier from AWS, READ ONLY. This field is populated when the provider manages the subnet.
+                        type: string
                       routeTableId:
                         description: RouteTableID is the routing table id associated with the subnet.
                         type: string
@@ -364,8 +368,19 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
+                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                    # ---
+                    # required:
+                    #   - id
                     type: object
                   type: array
+                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                  # ---
+                  # x-kubernetes-list-map-keys:
+                  #   - id
+                  # x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:
@@ -382,7 +397,7 @@
                       minimum: 1
                       type: integer
                     cidrBlock:
-                      description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                      description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16. Mutually exclusive with IPAMPool.
                       type: string
                     id:
                       description: ID is the vpc-id of the VPC this provider should use to create resources.
@@ -390,17 +405,45 @@
                     internetGatewayId:
                       description: InternetGatewayID is the id of the internet gateway associated with the VPC.
                       type: string
+                    ipamPool:
+                      description: IPAMPool defines the IPAMv4 pool to be used for VPC. Mutually exclusive with CidrBlock.
+                      properties:
+                        id:
+                          description: ID is the ID of the IPAM pool this provider should use to create VPC.
+                          type: string
+                        name:
+                          description: Name is the name of the IPAM pool this provider should use to create VPC.
+                          type: string
+                        netmaskLength:
+                          description: The netmask length of the IPv4 CIDR you want to allocate to VPC from an Amazon VPC IP Address Manager (IPAM) pool. Defaults to /16 for IPv4 if not specified.
+                          format: int64
+                          type: integer
+                      type: object
                     ipv6:
                       description: IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.
                       properties:
                         cidrBlock:
-                          description: CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.
+                          description: CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6. Mutually exclusive with IPAMPool.
                           type: string
                         egressOnlyInternetGatewayId:
                           description: EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.
                           type: string
+                        ipamPool:
+                          description: IPAMPool defines the IPAMv6 pool to be used for VPC. Mutually exclusive with CidrBlock.
+                          properties:
+                            id:
+                              description: ID is the ID of the IPAM pool this provider should use to create VPC.
+                              type: string
+                            name:
+                              description: Name is the name of the IPAM pool this provider should use to create VPC.
+                              type: string
+                            netmaskLength:
+                              description: The netmask length of the IPv4 CIDR you want to allocate to VPC from an Amazon VPC IP Address Manager (IPAM) pool. Defaults to /16 for IPv4 if not specified.
+                              format: int64
+                              type: integer
+                          type: object
                         poolId:
-                          description: PoolID is the IP pool which must be defined in case of BYO IP is defined.
+                          description: PoolID is the IP pool which must be defined in case of BYO IP is defined. Must be specified if CidrBlock is set. Mutually exclusive with IPAMPool.
                           type: string
                       type: object
                     tags:
@@ -1093,7 +1136,7 @@
                                 type: string
                               type: array
                             protocol:
-                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                               enum:
                                 - "-1"
                                 - "4"
@@ -1101,6 +1144,7 @@
                                 - udp
                                 - icmp
                                 - "58"
+                                - "50"
                               type: string
                             sourceSecurityGroupIds:
                               description: The security group id to allow access from. Cannot be specified with CidrBlocks.

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -58,6 +58,30 @@
             controlPlaneLoadBalancer:
               description: ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.
               properties:
+                additionalListeners:
+                  description: AdditionalListeners sets the additional listeners for the control plane load balancer. This is only applicable to Network Load Balancer (NLB) types for the time being.
+                  items:
+                    description: AdditionalListenerSpec defines the desired state of an additional listener on an AWS load balancer.
+                    properties:
+                      port:
+                        description: Port sets the port for the additional listener.
+                        format: int64
+                        maximum: 65535
+                        minimum: 1
+                        type: integer
+                      protocol:
+                        default: TCP
+                        description: Protocol sets the protocol for the additional listener. Currently only TCP is supported.
+                        enum:
+                          - TCP
+                        type: string
+                    required:
+                      - port
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - port
+                  x-kubernetes-list-type: map
                 additionalSecurityGroups:
                   description: AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer
                   items:
@@ -102,7 +126,7 @@
                           type: string
                         type: array
                       protocol:
-                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                         enum:
                           - "-1"
                           - "4"
@@ -110,6 +134,7 @@
                           - udp
                           - icmp
                           - "58"
+                          - "50"
                         type: string
                       sourceSecurityGroupIds:
                         description: The security group id to allow access from. Cannot be specified with CidrBlocks.
@@ -223,7 +248,7 @@
                           type: string
                         type: array
                       protocol:
-                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                        description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                         enum:
                           - "-1"
                           - "4"
@@ -231,6 +256,7 @@
                           - udp
                           - icmp
                           - "58"
+                          - "50"
                         type: string
                       sourceSecurityGroupIds:
                         description: The security group id to allow access from. Cannot be specified with CidrBlocks.
@@ -305,7 +331,7 @@
                         description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC.
                         type: string
                       id:
-                        description: ID defines a unique identifier to reference this resource.
+                        description: "ID defines a unique identifier to reference this resource. If you're bringing your subnet, set the AWS subnet-id here, it must start with `subnet-`. \n When the VPC is managed by CAPA, and you'd like the provider to create a subnet for you, the id can be set to any placeholder value that does not start with `subnet-`; upon creation, the subnet AWS identifier will be populated in the `ResourceID` field and the `id` field is going to be used as the subnet name. If you specify a tag called `Name`, it takes precedence."
                         type: string
                       ipv6CidrBlock:
                         description: IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
@@ -319,6 +345,9 @@
                       natGatewayId:
                         description: NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.
                         type: string
+                      resourceID:
+                        description: ResourceID is the subnet identifier from AWS, READ ONLY. This field is populated when the provider manages the subnet.
+                        type: string
                       routeTableId:
                         description: RouteTableID is the routing table id associated with the subnet.
                         type: string
@@ -327,8 +356,19 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
+                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                    # ---
+                    # required:
+                    #   - id
                     type: object
                   type: array
+                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                  # ---
+                  # x-kubernetes-list-map-keys:
+                  #   - id
+                  # x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:
@@ -345,7 +385,7 @@
                       minimum: 1
                       type: integer
                     cidrBlock:
-                      description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                      description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16. Mutually exclusive with IPAMPool.
                       type: string
                     id:
                       description: ID is the vpc-id of the VPC this provider should use to create resources.
@@ -353,17 +393,45 @@
                     internetGatewayId:
                       description: InternetGatewayID is the id of the internet gateway associated with the VPC.
                       type: string
+                    ipamPool:
+                      description: IPAMPool defines the IPAMv4 pool to be used for VPC. Mutually exclusive with CidrBlock.
+                      properties:
+                        id:
+                          description: ID is the ID of the IPAM pool this provider should use to create VPC.
+                          type: string
+                        name:
+                          description: Name is the name of the IPAM pool this provider should use to create VPC.
+                          type: string
+                        netmaskLength:
+                          description: The netmask length of the IPv4 CIDR you want to allocate to VPC from an Amazon VPC IP Address Manager (IPAM) pool. Defaults to /16 for IPv4 if not specified.
+                          format: int64
+                          type: integer
+                      type: object
                     ipv6:
                       description: IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.
                       properties:
                         cidrBlock:
-                          description: CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.
+                          description: CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6. Mutually exclusive with IPAMPool.
                           type: string
                         egressOnlyInternetGatewayId:
                           description: EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.
                           type: string
+                        ipamPool:
+                          description: IPAMPool defines the IPAMv6 pool to be used for VPC. Mutually exclusive with CidrBlock.
+                          properties:
+                            id:
+                              description: ID is the ID of the IPAM pool this provider should use to create VPC.
+                              type: string
+                            name:
+                              description: Name is the name of the IPAM pool this provider should use to create VPC.
+                              type: string
+                            netmaskLength:
+                              description: The netmask length of the IPv4 CIDR you want to allocate to VPC from an Amazon VPC IP Address Manager (IPAM) pool. Defaults to /16 for IPv4 if not specified.
+                              format: int64
+                              type: integer
+                          type: object
                         poolId:
-                          description: PoolID is the IP pool which must be defined in case of BYO IP is defined.
+                          description: PoolID is the IP pool which must be defined in case of BYO IP is defined. Must be specified if CidrBlock is set. Mutually exclusive with IPAMPool.
                           type: string
                       type: object
                     tags:
@@ -396,10 +464,11 @@
                   items:
                     type: string
                   type: array
+                presignedURLDuration:
+                  description: "PresignedURLDuration defines the duration for which presigned URLs are valid. \n This is used to generate presigned URLs for S3 Bucket objects, which are used by control-plane and worker nodes to fetch bootstrap data. \n When enabled, the IAM instance profiles specified are not used."
+                  type: string
               required:
-                - controlPlaneIAMInstanceProfile
                 - name
-                - nodesIAMInstanceProfiles
               type: object
             sshKeyName:
               description: SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)
@@ -855,7 +924,7 @@
                                 type: string
                               type: array
                             protocol:
-                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                              description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                               enum:
                                 - "-1"
                                 - "4"
@@ -863,6 +932,7 @@
                                 - udp
                                 - icmp
                                 - "58"
+                                - "50"
                               type: string
                             sourceSecurityGroupIds:
                               description: The security group id to allow access from. Cannot be specified with CidrBlocks.

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -77,6 +77,30 @@
                     controlPlaneLoadBalancer:
                       description: ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.
                       properties:
+                        additionalListeners:
+                          description: AdditionalListeners sets the additional listeners for the control plane load balancer. This is only applicable to Network Load Balancer (NLB) types for the time being.
+                          items:
+                            description: AdditionalListenerSpec defines the desired state of an additional listener on an AWS load balancer.
+                            properties:
+                              port:
+                                description: Port sets the port for the additional listener.
+                                format: int64
+                                maximum: 65535
+                                minimum: 1
+                                type: integer
+                              protocol:
+                                default: TCP
+                                description: Protocol sets the protocol for the additional listener. Currently only TCP is supported.
+                                enum:
+                                  - TCP
+                                type: string
+                            required:
+                              - port
+                            type: object
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - port
+                          x-kubernetes-list-type: map
                         additionalSecurityGroups:
                           description: AdditionalSecurityGroups sets the security groups used by the load balancer. Expected to be security group IDs This is optional - if not provided new security groups will be created for the load balancer
                           items:
@@ -121,7 +145,7 @@
                                   type: string
                                 type: array
                               protocol:
-                                description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                                description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                                 enum:
                                   - "-1"
                                   - "4"
@@ -129,6 +153,7 @@
                                   - udp
                                   - icmp
                                   - "58"
+                                  - "50"
                                 type: string
                               sourceSecurityGroupIds:
                                 description: The security group id to allow access from. Cannot be specified with CidrBlocks.
@@ -242,7 +267,7 @@
                                   type: string
                                 type: array
                               protocol:
-                                description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6).
+                                description: Protocol is the protocol for the ingress rule. Accepted values are "-1" (all), "4" (IP in IP),"tcp", "udp", "icmp", and "58" (ICMPv6), "50" (ESP).
                                 enum:
                                   - "-1"
                                   - "4"
@@ -250,6 +275,7 @@
                                   - udp
                                   - icmp
                                   - "58"
+                                  - "50"
                                 type: string
                               sourceSecurityGroupIds:
                                 description: The security group id to allow access from. Cannot be specified with CidrBlocks.
@@ -324,7 +350,7 @@
                                 description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC.
                                 type: string
                               id:
-                                description: ID defines a unique identifier to reference this resource.
+                                description: "ID defines a unique identifier to reference this resource. If you're bringing your subnet, set the AWS subnet-id here, it must start with `subnet-`. \n When the VPC is managed by CAPA, and you'd like the provider to create a subnet for you, the id can be set to any placeholder value that does not start with `subnet-`; upon creation, the subnet AWS identifier will be populated in the `ResourceID` field and the `id` field is going to be used as the subnet name. If you specify a tag called `Name`, it takes precedence."
                                 type: string
                               ipv6CidrBlock:
                                 description: IPv6CidrBlock is the IPv6 CIDR block to be used when the provider creates a managed VPC. A subnet can have an IPv4 and an IPv6 address. IPv6 is only supported in managed clusters, this field cannot be set on AWSCluster object.
@@ -338,6 +364,9 @@
                               natGatewayId:
                                 description: NatGatewayID is the NAT gateway id associated with the subnet. Ignored unless the subnet is managed by the provider, in which case this is set on the public subnet where the NAT gateway resides. It is then used to determine routes for private subnets in the same AZ as the public subnet.
                                 type: string
+                              resourceID:
+                                description: ResourceID is the subnet identifier from AWS, READ ONLY. This field is populated when the provider manages the subnet.
+                                type: string
                               routeTableId:
                                 description: RouteTableID is the routing table id associated with the subnet.
                                 type: string
@@ -346,8 +375,19 @@
                                   type: string
                                 description: Tags is a collection of tags describing the resource.
                                 type: object
+                            # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                            # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                            # ---
+                            # required:
+                            #   - id
                             type: object
                           type: array
+                          # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                          # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                          # ---
+                          # x-kubernetes-list-map-keys:
+                          #   - id
+                          # x-kubernetes-list-type: map
                         vpc:
                           description: VPC configuration.
                           properties:
@@ -364,7 +404,7 @@
                               minimum: 1
                               type: integer
                             cidrBlock:
-                              description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16.
+                              description: CidrBlock is the CIDR block to be used when the provider creates a managed VPC. Defaults to 10.0.0.0/16. Mutually exclusive with IPAMPool.
                               type: string
                             id:
                               description: ID is the vpc-id of the VPC this provider should use to create resources.
@@ -372,17 +412,45 @@
                             internetGatewayId:
                               description: InternetGatewayID is the id of the internet gateway associated with the VPC.
                               type: string
+                            ipamPool:
+                              description: IPAMPool defines the IPAMv4 pool to be used for VPC. Mutually exclusive with CidrBlock.
+                              properties:
+                                id:
+                                  description: ID is the ID of the IPAM pool this provider should use to create VPC.
+                                  type: string
+                                name:
+                                  description: Name is the name of the IPAM pool this provider should use to create VPC.
+                                  type: string
+                                netmaskLength:
+                                  description: The netmask length of the IPv4 CIDR you want to allocate to VPC from an Amazon VPC IP Address Manager (IPAM) pool. Defaults to /16 for IPv4 if not specified.
+                                  format: int64
+                                  type: integer
+                              type: object
                             ipv6:
                               description: IPv6 contains ipv6 specific settings for the network. Supported only in managed clusters. This field cannot be set on AWSCluster object.
                               properties:
                                 cidrBlock:
-                                  description: CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6.
+                                  description: CidrBlock is the CIDR block provided by Amazon when VPC has enabled IPv6. Mutually exclusive with IPAMPool.
                                   type: string
                                 egressOnlyInternetGatewayId:
                                   description: EgressOnlyInternetGatewayID is the id of the egress only internet gateway associated with an IPv6 enabled VPC.
                                   type: string
+                                ipamPool:
+                                  description: IPAMPool defines the IPAMv6 pool to be used for VPC. Mutually exclusive with CidrBlock.
+                                  properties:
+                                    id:
+                                      description: ID is the ID of the IPAM pool this provider should use to create VPC.
+                                      type: string
+                                    name:
+                                      description: Name is the name of the IPAM pool this provider should use to create VPC.
+                                      type: string
+                                    netmaskLength:
+                                      description: The netmask length of the IPv4 CIDR you want to allocate to VPC from an Amazon VPC IP Address Manager (IPAM) pool. Defaults to /16 for IPv4 if not specified.
+                                      format: int64
+                                      type: integer
+                                  type: object
                                 poolId:
-                                  description: PoolID is the IP pool which must be defined in case of BYO IP is defined.
+                                  description: PoolID is the IP pool which must be defined in case of BYO IP is defined. Must be specified if CidrBlock is set. Mutually exclusive with IPAMPool.
                                   type: string
                               type: object
                             tags:
@@ -415,10 +483,11 @@
                           items:
                             type: string
                           type: array
+                        presignedURLDuration:
+                          description: "PresignedURLDuration defines the duration for which presigned URLs are valid. \n This is used to generate presigned URLs for S3 Bucket objects, which are used by control-plane and worker nodes to fetch bootstrap data. \n When enabled, the IAM instance profiles specified are not used."
+                          type: string
                       required:
-                        - controlPlaneIAMInstanceProfile
                         - name
-                        - nodesIAMInstanceProfiles
                       type: object
                     sshKeyName:
                       description: SSHKeyName is the name of the ssh key to attach to the bastion host. Valid values are empty string (do not use SSH keys), a valid SSH key name, or omitted (use the default SSH key name)

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -20,6 +20,13 @@
                 type: string
               description: AdditionalTags is an optional set of tags to add to an instance, in addition to the ones added by default by the AWS provider.
               type: object
+            availabilityZoneSubnetType:
+              description: AvailabilityZoneSubnetType specifies which type of subnets to use when an availability zone is specified.
+              enum:
+                - public
+                - private
+                - all
+              type: string
             availabilityZones:
               description: AvailabilityZones is an array of availability zones instances can run in
               items:
@@ -81,6 +88,38 @@
                 imageLookupOrg:
                   description: ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.
                   type: string
+                instanceMetadataOptions:
+                  description: InstanceMetadataOptions defines the behavior for applying metadata to instances.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1"
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: optional
+                      description: "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: optional"
+                      enum:
+                        - optional
+                        - required
+                      type: string
+                    instanceMetadataTags:
+                      default: disabled
+                      description: "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                  type: object
                 instanceType:
                   description: 'InstanceType is the type of instance to create. Example: m4.xlarge'
                   type: string
@@ -162,6 +201,7 @@
                       description: OnDemandAllocationStrategy indicates how to allocate instance types to fulfill On-Demand capacity.
                       enum:
                         - prioritized
+                        - lowest-price
                       type: string
                     onDemandBaseCapacity:
                       default: 0
@@ -177,6 +217,8 @@
                       enum:
                         - lowest-price
                         - capacity-optimized
+                        - capacity-optimized-prioritized
+                        - price-capacity-optimized
                       type: string
                   type: object
                 overrides:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachines.infrastructure.cluster.x-k8s.io.yaml
@@ -92,6 +92,11 @@
                   description: Version defines which version of Ignition will be used to generate bootstrap data.
                   enum:
                     - "2.3"
+                    - "3.0"
+                    - "3.1"
+                    - "3.2"
+                    - "3.3"
+                    - "3.4"
                   type: string
               type: object
             imageLookupBaseOS:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -112,6 +112,11 @@
                           description: Version defines which version of Ignition will be used to generate bootstrap data.
                           enum:
                             - "2.3"
+                            - "3.0"
+                            - "3.1"
+                            - "3.2"
+                            - "3.3"
+                            - "3.4"
                           type: string
                       type: object
                     imageLookupBaseOS:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -33,6 +33,13 @@
               description: AMIVersion defines the desired AMI release version. If no version number is supplied then the latest version for the Kubernetes version will be used
               minLength: 2
               type: string
+            availabilityZoneSubnetType:
+              description: AvailabilityZoneSubnetType specifies which type of subnets to use when an availability zone is specified.
+              enum:
+                - public
+                - private
+                - all
+              type: string
             availabilityZones:
               description: AvailabilityZones is an array of availability zones instances can run in
               items:
@@ -94,6 +101,38 @@
                 imageLookupOrg:
                   description: ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.
                   type: string
+                instanceMetadataOptions:
+                  description: InstanceMetadataOptions defines the behavior for applying metadata to instances.
+                  properties:
+                    httpEndpoint:
+                      default: enabled
+                      description: "Enables or disables the HTTP metadata endpoint on your instances. \n If you specify a value of disabled, you cannot access your instance metadata. \n Default: enabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                    httpPutResponseHopLimit:
+                      default: 1
+                      description: "The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel. \n Default: 1"
+                      format: int64
+                      maximum: 64
+                      minimum: 1
+                      type: integer
+                    httpTokens:
+                      default: optional
+                      description: "The state of token usage for your instance metadata requests. \n If the state is optional, you can choose to retrieve instance metadata with or without a session token on your request. If you retrieve the IAM role credentials without a token, the version 1.0 role credentials are returned. If you retrieve the IAM role credentials using a valid session token, the version 2.0 role credentials are returned. \n If the state is required, you must send a session token with any instance metadata retrieval requests. In this state, retrieving the IAM role credentials always returns the version 2.0 credentials; the version 1.0 credentials are not available. \n Default: optional"
+                      enum:
+                        - optional
+                        - required
+                      type: string
+                    instanceMetadataTags:
+                      default: disabled
+                      description: "Set to enabled to allow access to instance tags from the instance metadata. Set to disabled to turn off access to instance tags from the instance metadata. For more information, see Work with instance tags using the instance metadata (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS). \n Default: disabled"
+                      enum:
+                        - enabled
+                        - disabled
+                      type: string
+                  type: object
                 instanceType:
                   description: 'InstanceType is the type of instance to create. Example: m4.xlarge'
                   type: string

--- a/helm/cluster-api-provider-aws/templates/rbac.authorization.k8s.io_v1_clusterrole_capa-manager-role.yaml
+++ b/helm/cluster-api-provider-aws/templates/rbac.authorization.k8s.io_v1_clusterrole_capa-manager-role.yaml
@@ -144,6 +144,15 @@ rules:
   - patch
   - update
 - apiGroups:
+  - controlplane.cluster.x-k8s.io
+  resources:
+  - rosacontrolplanes
+  - rosacontrolplanes/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - events
@@ -335,6 +344,25 @@ rules:
   - infrastructure.cluster.x-k8s.io
   resources:
   - awsmanagedmachinepools/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - rosaclusters
+  verbs:
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - rosaclusters/status
   verbs:
   - get
   - patch

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -1,8 +1,9 @@
 name: cluster-api-provider-aws
-# This value can also be a commit (even works for `make generate`), but tags are preferred since those can include a
-# message and tell us explicitly that the commit is important. Please include the short commit SHA in the tag name,
-# such as `v2.0.2-gs-123abcd`.
-tag: v2.2.4-gs-f512f0b17  # upstream v2.2.4 + workaround for long-lasting broken subnets issue (https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4026) + S3 bucket tagging
+# This refers to a release in the Giant Swarm fork. The fork closely follows upstream releases unless hotfixes are
+# needed. Please read https://github.com/giantswarm/cluster-api-provider-aws/blob/main/README.md on how to create a
+# release. Please include the short commit SHA in the tag name, such as `v2.0.2-gs-123abcd`. After changing this
+# tag, please run `make generate` to update CRDs and other manifests.
+tag: v2.3.0-gs-c258494bd  # upstream v2.3.0
 
 infrastructure:
   image:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2870, namely the first step of the [suggested migration](https://github.com/giantswarm/roadmap/issues/2870#issuecomment-1827869770).

Note that since the old CRDs are used here, avoiding that the subnet `id` field is required for now, the `make verify` CI job is failing. That must be accepted until step two (update to actual, latest CRDs which make the field required).

See related cluster app changes:

- https://github.com/giantswarm/cluster-aws/pull/439
- https://github.com/giantswarm/cluster-eks/pull/43

### Checklist

- [x] Update changelog in CHANGELOG.md.