### PR TITLE
Upgrade CAPA CRDs to v2.3.0 including required subnet `id` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade CAPA CRDs to v2.3.0 including required subnet `id` field
+
 ## [2.7.0] - 2023-11-30
 
 ### Changed

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -372,19 +372,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                    # ---
-                    # required:
-                    #   - id
+                    required:
+                      - id
                     type: object
                   type: array
-                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                  # ---
-                  # x-kubernetes-list-map-keys:
-                  #   - id
-                  # x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -368,19 +368,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                    # ---
-                    # required:
-                    #   - id
+                    required:
+                      - id
                     type: object
                   type: array
-                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                  # ---
-                  # x-kubernetes-list-map-keys:
-                  #   - id
-                  # x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -356,19 +356,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                    # ---
-                    # required:
-                    #   - id
+                    required:
+                      - id
                     type: object
                   type: array
-                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                  # ---
-                  # x-kubernetes-list-map-keys:
-                  #   - id
-                  # x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -375,19 +375,13 @@
                                   type: string
                                 description: Tags is a collection of tags describing the resource.
                                 type: object
-                            # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                            # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                            # ---
-                            # required:
-                            #   - id
+                            required:
+                              - id
                             type: object
                           type: array
-                          # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                          # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                          # ---
-                          # x-kubernetes-list-map-keys:
-                          #   - id
-                          # x-kubernetes-list-type: map
+                          x-kubernetes-list-map-keys:
+                            - id
+                          x-kubernetes-list-type: map
                         vpc:
                           description: VPC configuration.
                           properties:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2870, step 2 of the smooth-ish migration (see https://github.com/giantswarm/roadmap/issues/2870#issuecomment-1827869770).

This must only be merged once MCs/WCs (CAPA EC2/EKS) have been upgraded i.e. after https://github.com/giantswarm/cluster-api-provider-aws-app/pull/193, https://github.com/giantswarm/cluster-aws/pull/439, https://github.com/giantswarm/cluster-eks/pull/43. But we can review already.

### Checklist

- [x] Update changelog in CHANGELOG.md.
