### PR TITLE
Revert CRDs upgrade since CAPA creates unlimited VPCs for EKS clusters because the subnet `id` field cannot be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Revert CRDs upgrade since CAPA creates unlimited VPCs for EKS clusters because the subnet `id` field cannot be set ([bug](https://github.com/giantswarm/roadmap/issues/3048))
+
 ## [2.8.0] - 2023-12-13
 
 ### Changed

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -372,13 +372,19 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    required:
-                      - id
+                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                    # ---
+                    # required:
+                    #   - id
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                    - id
-                  x-kubernetes-list-type: map
+                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                  # ---
+                  # x-kubernetes-list-map-keys:
+                  #   - id
+                  # x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -368,13 +368,19 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    required:
-                      - id
+                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                    # ---
+                    # required:
+                    #   - id
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                    - id
-                  x-kubernetes-list-type: map
+                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                  # ---
+                  # x-kubernetes-list-map-keys:
+                  #   - id
+                  # x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -356,13 +356,19 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    required:
-                      - id
+                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                    # ---
+                    # required:
+                    #   - id
                     type: object
                   type: array
-                  x-kubernetes-list-map-keys:
-                    - id
-                  x-kubernetes-list-type: map
+                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                  # ---
+                  # x-kubernetes-list-map-keys:
+                  #   - id
+                  # x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -375,13 +375,19 @@
                                   type: string
                                 description: Tags is a collection of tags describing the resource.
                                 type: object
-                            required:
-                              - id
+                            # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                            # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                            # ---
+                            # required:
+                            #   - id
                             type: object
                           type: array
-                          x-kubernetes-list-map-keys:
-                            - id
-                          x-kubernetes-list-type: map
+                          # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
+                          # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
+                          # ---
+                          # x-kubernetes-list-map-keys:
+                          #   - id
+                          # x-kubernetes-list-type: map
                         vpc:
                           description: VPC configuration.
                           properties:


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3048. Until we fixed the actual issue upstream, we're going back to expected-working state of app version v2.7.1.

### Checklist

- [x] Update changelog in CHANGELOG.md.
