### PR TITLE
Backported fixes and features for CAPA v2.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Backported fixes and features for CAPA v2.3.x
+
+  - Enable transit encryption to S3 bucket
+  - Trigger machine pool instance refresh (node rollout) if bootstrap config reference changes
+  - Skip instance refresh attempt if ASG does not yet exist
+
 ## [2.8.1] - 2023-12-14
 
 ### Fixed

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -3,7 +3,7 @@ name: cluster-api-provider-aws
 # needed. Please read https://github.com/giantswarm/cluster-api-provider-aws/blob/main/README.md on how to create a
 # release. Please include the short commit SHA in the tag name, such as `v2.0.2-gs-123abcd`. After changing this
 # tag, please run `make generate` to update CRDs and other manifests.
-tag: v2.3.0-gs-c258494bd  # upstream v2.3.0
+tag: v2.3.0-gs-378440654  # upstream v2.3.0 + backported features/fixes (https://github.com/giantswarm/cluster-api-provider-aws/pull/576)
 
 infrastructure:
   image:


### PR DESCRIPTION
https://github.com/giantswarm/roadmap/issues/2217

Tested with latest cluster-aws and cluster-eks (WC creation and deletion). Each of the features worked fine in my test, including bootstrap config reference change (requires cluster-aws change https://github.com/giantswarm/cluster-aws/pull/457 which I'll finish later).

### Checklist

- [x] Update changelog in CHANGELOG.md.
