### PR TITLE
Cherry-pick important fixes (stuck ASG recon, machine pool node rollout if bootstrap config reference changes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Cherry-pick important fixes: [stuck ASG recon](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4662) and [machine pool node rollout if bootstrap config reference changes](https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4619)
+
 ## [2.8.0] - 2023-12-13
 
 ### Changed

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -3,7 +3,7 @@ name: cluster-api-provider-aws
 # needed. Please read https://github.com/giantswarm/cluster-api-provider-aws/blob/main/README.md on how to create a
 # release. Please include the short commit SHA in the tag name, such as `v2.0.2-gs-123abcd`. After changing this
 # tag, please run `make generate` to update CRDs and other manifests.
-tag: v2.3.0-gs-c258494bd  # upstream v2.3.0
+tag: 81a931a5ed766dfcee5ba52f05e2c98c36c20882  # upstream v2.3.0 + https://github.com/giantswarm/cluster-api-provider-aws/pull/576 (ASG recon fix, machine pool bootstrap reference rotation support)
 
 infrastructure:
   image:


### PR DESCRIPTION
Node rollout on `KubeadmConfig.spec` changes were tested and worked fine multiple times.

### Checklist

- [x] Update changelog in CHANGELOG.md.
