### PR TITLE
More backported fixes and features for CAPA v2.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Backported fixes and features for CAPA v2.3.x
+
+  - Use go 1.21.5, fix kubectl version detection after `--short` parameter was removed
+  - Make VPC creation idempotent to avoid indefinite creation of new VPCs if storage of the ID fails
+  - Log full ARN in GC error messages
+  - Fix deregistering of deleted CAPI Machines
+  - ASG: do not set desired value for machinepool which have externally managed replicas
+
 ## [2.9.0] - 2023-12-21
 
 ### Changed

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -3,7 +3,7 @@ name: cluster-api-provider-aws
 # needed. Please read https://github.com/giantswarm/cluster-api-provider-aws/blob/main/README.md on how to create a
 # release. Please include the short commit SHA in the tag name, such as `v2.0.2-gs-123abcd`. After changing this
 # tag, please run `make generate` to update CRDs and other manifests.
-tag: v2.3.0-gs-378440654  # upstream v2.3.0 + backported features/fixes (https://github.com/giantswarm/cluster-api-provider-aws/pull/576)
+tag: v2.3.0-gs-947dff28f  # upstream v2.3.0 + backported features/fixes (https://github.com/giantswarm/cluster-api-provider-aws/pull/576) + more backports (https://github.com/giantswarm/cluster-api-provider-aws/pull/580)
 
 infrastructure:
   image:


### PR DESCRIPTION
https://github.com/giantswarm/roadmap/issues/3048, contains https://github.com/giantswarm/cluster-api-provider-aws/pull/580

Already tested with EC2/EKS workload cluster creation and deletion.

After this, I can fix the subnet `id` field problem and update CRDs accordingly. Until then, the `make verify` action will still fail on purpose (see comments in there).

### Checklist

- [x] Update changelog in CHANGELOG.md.
