### PR TITLE
Update CRDs to make the subnet `id` field required again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update CRDs to make the subnet `id` field required again
+
 ## [2.10.1] - 2024-01-10
 
 ### Changed

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -372,19 +372,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                    # ---
-                    # required:
-                    #   - id
+                    required:
+                      - id
                     type: object
                   type: array
-                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                  # ---
-                  # x-kubernetes-list-map-keys:
-                  #   - id
-                  # x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -368,19 +368,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                    # ---
-                    # required:
-                    #   - id
+                    required:
+                      - id
                     type: object
                   type: array
-                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                  # ---
-                  # x-kubernetes-list-map-keys:
-                  #   - id
-                  # x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -356,19 +356,13 @@
                           type: string
                         description: Tags is a collection of tags describing the resource.
                         type: object
-                    # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                    # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                    # ---
-                    # required:
-                    #   - id
+                    required:
+                      - id
                     type: object
                   type: array
-                  # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                  # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                  # ---
-                  # x-kubernetes-list-map-keys:
-                  #   - id
-                  # x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - id
+                  x-kubernetes-list-type: map
                 vpc:
                   description: VPC configuration.
                   properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -375,19 +375,13 @@
                                   type: string
                                 description: Tags is a collection of tags describing the resource.
                                 type: object
-                            # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                            # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                            # ---
-                            # required:
-                            #   - id
+                            required:
+                              - id
                             type: object
                           type: array
-                          # While we migrate workload clusters to include the subnet `id` field (https://github.com/giantswarm/roadmap/issues/2870),
-                          # this is commented out on purpose in the first step so that reconciliation continues working for old cluster-aws versions.
-                          # ---
-                          # x-kubernetes-list-map-keys:
-                          #   - id
-                          # x-kubernetes-list-type: map
+                          x-kubernetes-list-map-keys:
+                            - id
+                          x-kubernetes-list-type: map
                         vpc:
                           description: VPC configuration.
                           properties:


### PR DESCRIPTION
https://github.com/giantswarm/roadmap/issues/2870

Back in again. This even worked fine with EKS WC creation. And even if it didn't work, EKS cluster creation is now safer after https://github.com/giantswarm/roadmap/issues/3048. EC2 cluster creation and deletion also works fine.

This change is only from `make generate`.

### Checklist

- [x] Update changelog in CHANGELOG.md.
