### PR TITLE
change-values-to-use-registry-from-config-repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change container image registry values name to use values from `config` repo.
+
 ## [2.15.0] - 2024-02-20
 
 ### Changed

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 
 images:
   - name: registry.k8s.io/cluster-api-aws/cluster-api-aws-controller
-    newName: "{{.Values.infrastructure.image.domain}}/{{.Values.infrastructure.image.name}}"
+    newName: "{{.Values.registry.domain}}/{{.Values.image.name}}"
     newTag: "{{.Values.tag}}"
 
 transformers:

--- a/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
+++ b/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
@@ -59,7 +59,7 @@ spec:
         env:
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: /home/.aws/credentials
-        image: '{{.Values.infrastructure.image.domain}}/{{.Values.infrastructure.image.name}}:{{.Values.tag}}'
+        image: '{{.Values.registry.domain}}/{{.Values.image.name}}:{{.Values.tag}}'
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/helm/cluster-api-provider-aws/templates/crd-install/crd-job.yaml
+++ b/helm/cluster-api-provider-aws/templates/crd-install/crd-job.yaml
@@ -31,7 +31,7 @@ spec:
         effect: NoSchedule
       containers:
       - name: kubectl
-        image: "{{ .Values.crdInstall.kubectl.image }}:{{ .Values.crdInstall.kubectl.tag }}"
+        image: "{{ .Values.registry.domain }}/{{ .Values.crdInstall.kubectl.image }}:{{ .Values.crdInstall.kubectl.tag }}"
         command:
         - sh
         - -c

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -13,10 +13,11 @@ name: cluster-api-provider-aws
 #   * do not place EKS nodes in the CNI subnets (https://github.com/giantswarm/cluster-api-provider-aws/pull/587)
 tag: v2.3.0-gs-e9c5ab62c
 
-infrastructure:
-  image:
-    domain: gsoci.azurecr.io
-    name: giantswarm/cluster-api-aws-controller
+registry:
+  domain: gsoci.azurecr.io
+
+image:
+  name: giantswarm/cluster-api-aws-controller
 
 ciliumNetworkPolicy:
   enabled: false

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -60,9 +60,6 @@ provider:
     accessKeyID: defaultID
     secretAccessKey: defaultKey
 
-registry:
-  domain: gsoci.azurecr.io
-
 verticalPodAutoscaler:
   enabled: true
 


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/3254

align registry helm value with `config` repo to be able reuse  it and deploy to China
 also add a registry domain for CRD install job