### PR TITLE
add-toleration-for-unitialized-nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
+- Remove toleration for old `node-role.kubernetes.io/master` taint.
+
 ## [2.15.2] - 2024-04-02
 
 ### Fixed

--- a/config/helm/deployment-toleration.yaml
+++ b/config/helm/deployment-toleration.yaml
@@ -1,0 +1,15 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: capa-controller-manager
+  namespace: capa-system
+spec:
+  template:
+    spec:
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: "node.cluster.x-k8s.io/uninitialized"
+        operator: "Exists"

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -40,6 +40,7 @@ patches:
   - path: deployment-requests-limits.yaml
   - path: deployment-seccomp.yaml
   - path: deployment-securitycontext.yaml
+  - path: deployment-toleration.yaml
   - path: delete-namespace.yaml
   - path: delete-serviceaccount-annotation.yaml
   - path: metrics-service-named-port.yaml

--- a/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
+++ b/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
@@ -113,9 +113,10 @@ spec:
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule
-        key: node-role.kubernetes.io/master
-      - effect: NoSchedule
         key: node-role.kubernetes.io/control-plane
+      - effect: NoSchedule
+        key: node.cluster.x-k8s.io/uninitialized
+        operator: Exists
       volumes:
       - name: cert
         secret:


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/30433

- Add toleration for `node.cluster.x-k8s.io/uninitialized` taint.
- Remove toleration for old `node-role.kubernetes.io/master` taint.

