### PR TITLE
Support adding custom secondary VPC CIDR blocks in `AWSCluster` (backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support adding custom secondary VPC CIDR blocks in `AWSCluster` (backport)
+
 ## [2.17.0] - 2024-04-25
 
 ### Added

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -447,6 +447,19 @@
                           description: PoolID is the IP pool which must be defined in case of BYO IP is defined. Must be specified if CidrBlock is set. Mutually exclusive with IPAMPool.
                           type: string
                       type: object
+                    secondaryCidrBlocks:
+                      description: SecondaryCidrBlocks are additional CIDR blocks to be associated when the provider creates a managed VPC. Defaults to none. Mutually exclusive with IPAMPool. This makes sense to use if, for example, you want to use a separate IP range for pods (e.g. Cilium ENI mode).
+                      items:
+                        description: VpcCidrBlock defines the CIDR block and settings to associate with the managed VPC. Currently, only IPv4 is supported.
+                        properties:
+                          ipv4CidrBlock:
+                            description: IPv4CidrBlock is the IPv4 CIDR block to associate with the managed VPC.
+                            minLength: 1
+                            type: string
+                        required:
+                          - ipv4CidrBlock
+                        type: object
+                      type: array
                     tags:
                       additionalProperties:
                         type: string

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -443,6 +443,19 @@
                           description: PoolID is the IP pool which must be defined in case of BYO IP is defined. Must be specified if CidrBlock is set. Mutually exclusive with IPAMPool.
                           type: string
                       type: object
+                    secondaryCidrBlocks:
+                      description: SecondaryCidrBlocks are additional CIDR blocks to be associated when the provider creates a managed VPC. Defaults to none. Mutually exclusive with IPAMPool. This makes sense to use if, for example, you want to use a separate IP range for pods (e.g. Cilium ENI mode).
+                      items:
+                        description: VpcCidrBlock defines the CIDR block and settings to associate with the managed VPC. Currently, only IPv4 is supported.
+                        properties:
+                          ipv4CidrBlock:
+                            description: IPv4CidrBlock is the IPv4 CIDR block to associate with the managed VPC.
+                            minLength: 1
+                            type: string
+                        required:
+                          - ipv4CidrBlock
+                        type: object
+                      type: array
                     tags:
                       additionalProperties:
                         type: string

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -431,6 +431,19 @@
                           description: PoolID is the IP pool which must be defined in case of BYO IP is defined. Must be specified if CidrBlock is set. Mutually exclusive with IPAMPool.
                           type: string
                       type: object
+                    secondaryCidrBlocks:
+                      description: SecondaryCidrBlocks are additional CIDR blocks to be associated when the provider creates a managed VPC. Defaults to none. Mutually exclusive with IPAMPool. This makes sense to use if, for example, you want to use a separate IP range for pods (e.g. Cilium ENI mode).
+                      items:
+                        description: VpcCidrBlock defines the CIDR block and settings to associate with the managed VPC. Currently, only IPv4 is supported.
+                        properties:
+                          ipv4CidrBlock:
+                            description: IPv4CidrBlock is the IPv4 CIDR block to associate with the managed VPC.
+                            minLength: 1
+                            type: string
+                        required:
+                          - ipv4CidrBlock
+                        type: object
+                      type: array
                     tags:
                       additionalProperties:
                         type: string

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -450,6 +450,19 @@
                                   description: PoolID is the IP pool which must be defined in case of BYO IP is defined. Must be specified if CidrBlock is set. Mutually exclusive with IPAMPool.
                                   type: string
                               type: object
+                            secondaryCidrBlocks:
+                              description: SecondaryCidrBlocks are additional CIDR blocks to be associated when the provider creates a managed VPC. Defaults to none. Mutually exclusive with IPAMPool. This makes sense to use if, for example, you want to use a separate IP range for pods (e.g. Cilium ENI mode).
+                              items:
+                                description: VpcCidrBlock defines the CIDR block and settings to associate with the managed VPC. Currently, only IPv4 is supported.
+                                properties:
+                                  ipv4CidrBlock:
+                                    description: IPv4CidrBlock is the IPv4 CIDR block to associate with the managed VPC.
+                                    minLength: 1
+                                    type: string
+                                required:
+                                  - ipv4CidrBlock
+                                type: object
+                              type: array
                             tags:
                               additionalProperties:
                                 type: string

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -13,7 +13,8 @@ name: cluster-api-provider-aws
 #   * do not place EKS nodes in the CNI subnets (https://github.com/giantswarm/cluster-api-provider-aws/pull/587)
 #   * add ID to secondary subnets in AWSCluster (https://github.com/giantswarm/cluster-api-provider-aws/pull/589)
 #   * add non root volumes to AWSMachinePools (https://github.com/giantswarm/cluster-api-provider-aws/pull/591)
-tag: v2.3.0-gs-16d1f6ed4
+#   * support adding custom secondary VPC CIDR blocks in `AWSCluster` (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4898)
+tag: v2.3.0-gs-e2651cb59
 
 registry:
   domain: gsoci.azurecr.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2563

Includes only https://github.com/giantswarm/cluster-api-provider-aws/pull/590 – needed to select the correct subnets for nodes vs. pods when using a secondary VPC CIDR (such as when using the Cilium ENI mode feature).

### Checklist

- [x] Update changelog in CHANGELOG.md.
