### PR TITLE
Make ServiceMonitor optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Make ServiceMonitor optional through `serviceMonitor.enabled` helm value (useful in mc-bootstrap).
+
 ## [2.18.0] - 2024-05-02
 
 ### Added

--- a/helm/cluster-api-provider-aws/files/copy/service-monitor.yaml
+++ b/helm/cluster-api-provider-aws/files/copy/service-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -11,3 +12,4 @@ spec:
   selector:
     matchLabels:
       cluster.x-k8s.io/provider: infrastructure-aws
+{{- end }}

--- a/helm/cluster-api-provider-aws/templates/service-monitor.yaml
+++ b/helm/cluster-api-provider-aws/templates/service-monitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -11,3 +12,4 @@ spec:
   selector:
     matchLabels:
       cluster.x-k8s.io/provider: infrastructure-aws
+{{- end }}

--- a/helm/cluster-api-provider-aws/values.schema.json
+++ b/helm/cluster-api-provider-aws/values.schema.json
@@ -160,6 +160,15 @@
                 }
             }
         },
+        "serviceMonitor": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            },
+            "default": true
+        },
         "verticalPodAutoscaler": {
             "type": "object",
             "properties": {

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -63,6 +63,9 @@ provider:
     accessKeyID: defaultID
     secretAccessKey: defaultKey
 
+serviceMonitor:
+  enabled: true
+
 verticalPodAutoscaler:
   enabled: true
 


### PR DESCRIPTION
This PR makes the ServiceMonitor introduced with https://github.com/giantswarm/cluster-api-provider-aws-app/pull/225 optional.
It is still enabled by default, but it can be disabled through the helm value `serviceMonitor.enabled=false`.

This is necessary for example in mc-bootstrap, where the initial bootstrapping vcluster does not have the ServiceMonitor CRD (and we certainly don't want prometheus there).

### Checklist

- [x] Update changelog in CHANGELOG.md.
