### PR TITLE
Delete machine pool user data files that did not get deleted yet by the lifecycle policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix for the new feature of writing user data to S3 bucket for `AWSMachinePool`: on cluster deletion, delete machine pool user data files that did not get deleted yet by the S3 bucket lifecycle policy. Otherwise, CAPA would have left the S3 bucket behind on deletion since it was not empty.
+
 ## [2.19.0] - 2024-06-06
 
 ### Added

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -14,8 +14,8 @@ name: cluster-api-provider-aws
 #   * add ID to secondary subnets in AWSCluster (https://github.com/giantswarm/cluster-api-provider-aws/pull/589)
 #   * add non root volumes to AWSMachinePools (https://github.com/giantswarm/cluster-api-provider-aws/pull/591)
 #   * support adding custom secondary VPC CIDR blocks in `AWSCluster` (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4898)
-#   * support S3 bucket storage for user data of `AWSMachinePool` (https://github.com/giantswarm/cluster-api-provider-aws/pull/592)
-tag: v2.3.0-gs-0bcf5b8ab
+#   * support S3 bucket storage for user data of `AWSMachinePool` (https://github.com/giantswarm/cluster-api-provider-aws/pull/592 + https://github.com/giantswarm/cluster-api-provider-aws/pull/593)
+tag: v2.3.0-gs-TODO_FILL_ME_AFTER_MERGING_THIS_PR_https://github.com/giantswarm/cluster-api-provider-aws/pull/593
 
 registry:
   domain: gsoci.azurecr.io

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -14,8 +14,9 @@ name: cluster-api-provider-aws
 #   * add ID to secondary subnets in AWSCluster (https://github.com/giantswarm/cluster-api-provider-aws/pull/589)
 #   * add non root volumes to AWSMachinePools (https://github.com/giantswarm/cluster-api-provider-aws/pull/591)
 #   * support adding custom secondary VPC CIDR blocks in `AWSCluster` (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4898)
-#   * support S3 bucket storage for user data of `AWSMachinePool` (https://github.com/giantswarm/cluster-api-provider-aws/pull/592 + https://github.com/giantswarm/cluster-api-provider-aws/pull/593)
-tag: v2.3.0-gs-TODO_FILL_ME_AFTER_MERGING_THIS_PR_https://github.com/giantswarm/cluster-api-provider-aws/pull/593
+#   * support S3 bucket storage for user data of `AWSMachinePool` (https://github.com/giantswarm/cluster-api-provider-aws/pull/592)
+#   * Delete machine pool user data files that did not get deleted yet by the lifecycle policy (https://github.com/giantswarm/cluster-api-provider-aws/pull/593)
+tag: v2.3.0-gs-97afceef9
 
 registry:
   domain: gsoci.azurecr.io


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3442

The `tag` must first be filled in after https://github.com/giantswarm/cluster-api-provider-aws/pull/593 is merged and manually tagged. Therefore marking this as draft.

### Checklist

- [x] Update changelog in CHANGELOG.md.
