### PR TITLE
Cancel instance refresh on any relevant change to ASG, delete machine pool user data file from S3 when pruning an old launch template version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Cancel instance refresh on any relevant change to ASG instead of blocking until previous one is finished (which may have led to failing nodes due to outdated join token)
+- Try deleting machine pool user data file from S3 when pruning an old launch template version
+
 ## [2.19.1] - 2024-06-25
 
 ### Fixed

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -14,9 +14,15 @@ name: cluster-api-provider-aws
 #   * add ID to secondary subnets in AWSCluster (https://github.com/giantswarm/cluster-api-provider-aws/pull/589)
 #   * add non root volumes to AWSMachinePools (https://github.com/giantswarm/cluster-api-provider-aws/pull/591)
 #   * support adding custom secondary VPC CIDR blocks in `AWSCluster` (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/4898)
-#   * support S3 bucket storage for user data of `AWSMachinePool` (https://github.com/giantswarm/cluster-api-provider-aws/pull/592)
-#   * Delete machine pool user data files that did not get deleted yet by the lifecycle policy (https://github.com/giantswarm/cluster-api-provider-aws/pull/593)
-tag: v2.3.0-gs-97afceef9
+#   * S3 storage for user data
+#     * Support S3 bucket storage for user data of `AWSMachinePool` (https://github.com/giantswarm/cluster-api-provider-aws/pull/592)
+#     * Delete machine pool user data files that did not get deleted yet by the lifecycle policy (https://github.com/giantswarm/cluster-api-provider-aws/pull/593)
+#     * Test fixes (https://github.com/giantswarm/cluster-api-provider-aws/pull/596)
+#     * Cancel instance refresh on any relevant change to ASG instead of blocking until previous one is finished (which may have led to failing nodes due to outdated join token) (https://github.com/giantswarm/cluster-api-provider-aws/pull/598)
+#     * Use feature gate for S3 storage (https://github.com/giantswarm/cluster-api-provider-aws/pull/599)
+#     * Continue reconciliation after filling an empty `AWSMachinePool.status.launchTemplateVersion` field (https://github.com/giantswarm/cluster-api-provider-aws/pull/602)
+#     * Try deleting machine pool user data file from S3 when pruning an old launch template version (https://github.com/giantswarm/cluster-api-provider-aws/pull/601)
+tag: v2.3.5-gs-7e2e02d12
 
 registry:
   domain: gsoci.azurecr.io


### PR DESCRIPTION
This subsumes the improvements from https://github.com/giantswarm/roadmap/issues/3442 and https://github.com/giantswarm/giantswarm/issues/31105, as merged into our CAPA fork with these PRs:

- https://github.com/giantswarm/cluster-api-provider-aws/pull/596
- https://github.com/giantswarm/cluster-api-provider-aws/pull/598
- https://github.com/giantswarm/cluster-api-provider-aws/pull/599
- https://github.com/giantswarm/cluster-api-provider-aws/pull/601
- https://github.com/giantswarm/cluster-api-provider-aws/pull/602

Requires new permission via https://github.com/giantswarm/giantswarm-aws-account-prerequisites/pull/108 (I applied it to all CAPA MCs).

### Checklist

- [x] Update changelog in CHANGELOG.md.
