### PR TITLE
Drop dummy `caBundle` field to support Kubernetes 1.31

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Drop dummy `caBundle` field to support Kubernetes 1.31
+
 ## [2.31.0] - 2025-06-23
 
 ### Added

--- a/config/helm/crd_webhook.yaml
+++ b/config/helm/crd_webhook.yaml
@@ -12,9 +12,6 @@ spec:
       - v1
       - v1beta1
       clientConfig:
-        # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
-        # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)
-        caBundle: Cg==
         service:
           namespace: '{{ .Release.Namespace }}'
           name: capa-webhook-service

--- a/helm/cluster-api-provider-aws/files/bootstrap/bases/eksconfigs.bootstrap.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/bootstrap/bases/eksconfigs.bootstrap.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/bootstrap/bases/eksconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/bootstrap/bases/eksconfigtemplates.bootstrap.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/controlplane/bases/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/bases/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/controlplane/bases/rosacontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/bases/rosacontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclustercontrolleridentities.infrastructure.cluster.x-k8s.io.yaml
@@ -24,7 +24,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclusterroleidentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclusterroleidentities.infrastructure.cluster.x-k8s.io.yaml
@@ -24,7 +24,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclusterstaticidentities.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclusterstaticidentities.infrastructure.cluster.x-k8s.io.yaml
@@ -24,7 +24,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsfargateprofiles.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsfargateprofiles.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmachines.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmachines.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmachinetemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmachinetemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmanagedclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmanagedclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/awsmanagedmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/rosaclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/rosaclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/files/infrastructure/bases/rosamachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/bases/rosamachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -23,7 +23,6 @@ spec:
     strategy: Webhook
     webhook:
       clientConfig:
-        caBundle: Cg==
         service:
           name: capa-webhook-service
           namespace: '{{ .Release.Namespace }}'

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -18,7 +18,8 @@ name: cluster-api-provider-aws
 #   * Don't overwrite subnet spec tags with AWS tags (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5474)
 #   * Launchtemplate needs to be updated if spot options are changed (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5496)
 #   * Check control plane version skew before creating new launch template version (https://github.com/giantswarm/cluster-api-provider-aws/pull/624)
-tag: v2.7.1-gs-dddf7093c
+#   * Remove placeholder CA bundle (https://github.com/giantswarm/cluster-api-provider-aws/pull/625)
+tag: v2.7.1-gs-9ab223543
 
 registry:
   domain: gsoci.azurecr.io


### PR DESCRIPTION
Same as https://github.com/giantswarm/cluster-api-app/pull/283

### Checklist

- [x] Update changelog in CHANGELOG.md.
