### PR TITLE
Add AWSMachines to back the EC2 instances in AWSMachinePools and AWSManagedMachinePools, add feature gate for this feature (defaults to off)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add feature gate for machine pool machines (defaults to off)
+
 ### Changed
 
 - Remove unused values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add feature gate for machine pool machines (defaults to off)
+- Add AWSMachines to back the EC2 instances in AWSMachinePools and AWSManagedMachinePools, add feature gate for this feature (defaults to off)
 
 ### Changed
 

--- a/config/helm/deployment-args.yaml
+++ b/config/helm/deployment-args.yaml
@@ -12,7 +12,8 @@ spec:
           args:
             - --leader-elect
             - --metrics-bind-addr=0.0.0.0:8443
-            - --feature-gates=EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=true,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true,ExternalResourceGC=true,BootstrapFormatIgnition=true
+            - |
+              --feature-gates=EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=true,MachinePoolMachines={{ required "capaFeatureGates.machinePoolMachines is required" .Values.capaFeatureGates.machinePoolMachines | ternary "true" "false" }},EventBridgeInstanceState=false,AutoControllerIdentityCreator=true,ExternalResourceGC=true,BootstrapFormatIgnition=true
             - --watch-filter=capi
             # We need to set the sync-period to 2m to improve scale-up time, currently there is no watch in the capa controller that update the provideridlist. Upstream issues https://github.com/kubernetes-sigs/cluster-api/issues/9858 and https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/4618
             - --sync-period=2m

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachinepools.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmachinepools.infrastructure.cluster.x-k8s.io.yaml
@@ -734,6 +734,9 @@
                 can be added as events to the Machine object and/or logged in the
                 controller's output.
               type: string
+            infrastructureMachineKind:
+              description: InfrastructureMachineKind is the kind of the infrastructure resources behind MachinePool Machines.
+              type: string
             instances:
               description: Instances contains the status for each instance in the pool
               items:

--- a/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
+++ b/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
@@ -53,7 +53,8 @@ spec:
       - args:
         - --leader-elect
         - --metrics-bind-addr=0.0.0.0:8443
-        - --feature-gates=EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=true,EventBridgeInstanceState=false,AutoControllerIdentityCreator=true,ExternalResourceGC=true,BootstrapFormatIgnition=true
+        - |
+          --feature-gates=EKS=true,EKSEnableIAM=true,EKSAllowAddRoles=false,EKSFargate=false,MachinePool=true,MachinePoolMachines={{ required "capaFeatureGates.machinePoolMachines is required" .Values.capaFeatureGates.machinePoolMachines | ternary "true" "false" }},EventBridgeInstanceState=false,AutoControllerIdentityCreator=true,ExternalResourceGC=true,BootstrapFormatIgnition=true
         - --watch-filter=capi
         - --sync-period=2m
         - --v=0

--- a/helm/cluster-api-provider-aws/templates/rbac.authorization.k8s.io_v1_clusterrole_capa-manager-role.yaml
+++ b/helm/cluster-api-provider-aws/templates/rbac.authorization.k8s.io_v1_clusterrole_capa-manager-role.yaml
@@ -134,6 +134,14 @@ rules:
   - cluster.x-k8s.io
   resources:
   - machines
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
   - machines/status
   verbs:
   - get
@@ -318,6 +326,7 @@ rules:
   resources:
   - awsmachines
   verbs:
+  - create
   - delete
   - get
   - list

--- a/helm/cluster-api-provider-aws/values.schema.json
+++ b/helm/cluster-api-provider-aws/values.schema.json
@@ -55,6 +55,15 @@
                 }
             }
         },
+        "capaFeatureGates": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "machinePoolMachines": {
+                    "type": "boolean"
+                }
+            }
+        },
         "aws": {
             "type": "object",
             "properties": {

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -20,7 +20,8 @@ name: cluster-api-provider-aws
 #   * Check control plane version skew before creating new launch template version (https://github.com/giantswarm/cluster-api-provider-aws/pull/624)
 #   * Remove placeholder CA bundle (https://github.com/giantswarm/cluster-api-provider-aws/pull/625)
 #   * Add feature gate environment variable for machine pool machines (https://github.com/giantswarm/cluster-api-provider-aws/pull/627)
-tag: v2.7.1-gs-aa2805a5b
+#   * Add AWSMachines to back the EC2 instances in AWSMachinePools and AWSManagedMachinePools (https://github.com/giantswarm/cluster-api-provider-aws/pull/629)
+tag: v2.7.1-gs-d8be1df2d
 
 registry:
   domain: gsoci.azurecr.io

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -19,7 +19,8 @@ name: cluster-api-provider-aws
 #   * Launchtemplate needs to be updated if spot options are changed (https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5496)
 #   * Check control plane version skew before creating new launch template version (https://github.com/giantswarm/cluster-api-provider-aws/pull/624)
 #   * Remove placeholder CA bundle (https://github.com/giantswarm/cluster-api-provider-aws/pull/625)
-tag: v2.7.1-gs-9ab223543
+#   * Add feature gate environment variable for machine pool machines (https://github.com/giantswarm/cluster-api-provider-aws/pull/627)
+tag: v2.7.1-gs-aa2805a5b
 
 registry:
   domain: gsoci.azurecr.io
@@ -35,6 +36,9 @@ crdInstall:
   kubectl:
     image: "giantswarm/kubectl"
     tag: "1.24.10"
+
+capaFeatureGates:
+  machinePoolMachines: false
 
 aws:
   arn: defaultARN


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28006

With the feature flag, we want to test this for a short whlie on a test management cluster.

### Checklist

- [x] Update changelog in CHANGELOG.md.
