### PR TITLE
Giant Swarm specific, temporary hack: Allow fine-grained control which workload clusters get reconciled with the MachinePool Machines feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Giant Swarm specific, temporary hack: allow fine-grained control which workload clusters get reconciled with the MachinePool Machines feature
+
 ## [2.33.2] - 2025-09-10
 
 ### Fixed

--- a/config/helm/deployment-machine-pool-machines-feature-gate.yaml
+++ b/config/helm/deployment-machine-pool-machines-feature-gate.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /spec/template/spec/containers/0/env/-
+  value:
+    name: GIANT_SWARM_CAPA_MACHINE_POOL_MACHINES_ONLY_FOR_CLUSTER_NAME_REGEX
+    # No spaces in the Go template since kustomize otherwise breaks the string across multiple lines!
+    value: '{{.Values.capaFeatureGates.machinePoolMachinesOnlyForClusterNameRegex}}'

--- a/config/helm/kustomization.yaml
+++ b/config/helm/kustomization.yaml
@@ -51,3 +51,9 @@ patches:
   - path: webhook-service-named-port.yaml
   - path: certificate.yaml
   - path: secret.yaml
+
+  - path: deployment-machine-pool-machines-feature-gate.yaml
+    target:
+      kind: Deployment
+      name: capa-controller-manager
+      namespace: capa-system

--- a/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
+++ b/helm/cluster-api-provider-aws/templates/apps_v1_deployment_capa-controller-manager.yaml
@@ -61,6 +61,8 @@ spec:
         env:
         - name: AWS_SHARED_CREDENTIALS_FILE
           value: /home/.aws/credentials
+        - name: GIANT_SWARM_CAPA_MACHINE_POOL_MACHINES_ONLY_FOR_CLUSTER_NAME_REGEX
+          value: '{{.Values.capaFeatureGates.machinePoolMachinesOnlyForClusterNameRegex}}'
         image: '{{.Values.registry.domain}}/{{.Values.image.name}}:{{.Values.tag}}'
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/helm/cluster-api-provider-aws/values.schema.json
+++ b/helm/cluster-api-provider-aws/values.schema.json
@@ -61,6 +61,9 @@
             "properties": {
                 "machinePoolMachines": {
                     "type": "boolean"
+                },
+                "machinePoolMachinesOnlyForClusterNameRegex": {
+                    "type": "string"
                 }
             }
         },

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -23,7 +23,8 @@ name: cluster-api-provider-aws
 #   * Add AWSMachines to back the EC2 instances in AWSMachinePools and AWSManagedMachinePools (https://github.com/giantswarm/cluster-api-provider-aws/pull/629)
 #   * Only try to delete AWSMachine bootstrap data for non-machine pool machines (https://github.com/giantswarm/cluster-api-provider-aws/pull/630)
 #   * Fix cluster upgrade version skew (https://github.com/giantswarm/cluster-api-provider-aws/pull/631)
-tag: v2.7.1-gs-6d95db86f
+#   * Giant Swarm specific, temporary hack: allow fine-grained control which workload clusters get reconciled with the MachinePool Machines feature (https://github.com/giantswarm/cluster-api-provider-aws/pull/633)
+tag: v2.7.1-gs-32160154a
 
 registry:
   domain: gsoci.azurecr.io
@@ -42,6 +43,19 @@ crdInstall:
 
 capaFeatureGates:
   machinePoolMachines: false
+  # Giant Swarm specific to introduce the `MachinePoolMachines` feature gate gradually. This is a regex. If not empty and matching the cluster name, our CAPA fork reconciles it with the feature gate turned on (requiring `capaFeatureGates.machinePoolMachines=true`). This and the corresponding fork code will be removed once all MCs have the feature gate turned on.
+  #
+  # IMPORTANT: If this regex is left empty, the previous default behavior applies. That means
+  #            if `capaFeatureGates.machinePoolMachines=true`, the feature gate is enabled
+  #            for *all* workload clusters (and also the MC itself)!
+  #            As first migration step, it's recommended to first configure
+  #            `capaFeatureGates.machinePoolMachinesOnlyForClusterNameRegex=^(NOT-ON-ANY-CLUSTER-YET)$`
+  #            and check the logs. The line `MachinePool Machines feature gate check for cluster <namespace>/<name>: allow=false`
+  #            means that a cluster won't be reconciled with the feature, which is a good
+  #            starting point. Then, you can set `capaFeatureGates.machinePoolMachines=true`
+  #            and a regex which actually selects some or all clusters (don't forget the MC's name,
+  #            in addition to WC names).
+  machinePoolMachinesOnlyForClusterNameRegex: ""
 
 aws:
   arn: defaultARN


### PR DESCRIPTION
Contains https://github.com/giantswarm/cluster-api-provider-aws/pull/633, towards https://github.com/giantswarm/giantswarm/issues/28006

### Checklist

- [X] Update changelog in CHANGELOG.md.
