### PR TITLE
Bump CAPI to v1.12.2, k8s to v1.34 and controller-runtime to v0.22.5, switch to upstream fix for bug in "Changed dedicated host validation logic to require tenancy = host"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bump CAPI to v1.12.2, k8s to v1.34 and controller-runtime to v0.22.5 (backport of not yet merged upstream PR; needed for Kubernetes v1.35 support)
+- Switch to upstream fix for bug in "Changed dedicated host validation logic to require tenancy = host"
+
 ## [2.39.1] - 2026-04-22
 
 ### Fixed

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta1/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -118,9 +118,6 @@
                   description: port is the port on which the API server is serving.
                   format: int32
                   type: integer
-              required:
-                - host
-                - port
               type: object
             disableVPCCNI:
               default: false
@@ -899,7 +896,9 @@
                     description: EnvVar represents an environment variable present in a Container.
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -951,6 +950,42 @@
                                 type: string
                             required:
                               - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -220,9 +220,6 @@
                   description: port is the port on which the API server is serving.
                   format: int32
                   type: integer
-              required:
-                - host
-                - port
               type: object
             eksClusterName:
               description: |-
@@ -1043,7 +1040,9 @@
                     description: EnvVar represents an environment variable present in a Container.
                     properties:
                       name:
-                        description: Name of the environment variable. Must be a C_IDENTIFIER.
+                        description: |-
+                          Name of the environment variable.
+                          May consist of any printable ASCII characters except '='.
                         type: string
                       value:
                         description: |-
@@ -1095,6 +1094,42 @@
                                 type: string
                             required:
                               - fieldPath
+                            type: object
+                            x-kubernetes-map-type: atomic
+                          fileKeyRef:
+                            description: |-
+                              FileKeyRef selects a key of the env file.
+                              Requires the EnvFiles feature gate to be enabled.
+                            properties:
+                              key:
+                                description: |-
+                                  The key within the env file. An invalid key will prevent the pod from starting.
+                                  The keys defined within a source may consist of any printable ASCII characters except '='.
+                                  During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                type: string
+                              optional:
+                                default: false
+                                description: |-
+                                  Specify whether the file or its key must be defined. If the file or key
+                                  does not exist, then the env var is not published.
+                                  If optional is set to true and the specified key does not exist,
+                                  the environment variable will not be set in the Pod's containers.
+
+                                  If optional is set to false and the specified key does not exist,
+                                  an error will be returned during Pod creation.
+                                type: boolean
+                              path:
+                                description: |-
+                                  The path within the volume from which to select the file.
+                                  Must be relative and may not contain the '..' path or start with '..'.
+                                type: string
+                              volumeName:
+                                description: The name of the volume mount containing the env file.
+                                type: string
+                            required:
+                              - key
+                              - path
+                              - volumeName
                             type: object
                             x-kubernetes-map-type: atomic
                           resourceFieldRef:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanetemplates.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/awsmanagedcontrolplanetemplates.controlplane.cluster.x-k8s.io.yaml
@@ -226,9 +226,6 @@
                           description: port is the port on which the API server is serving.
                           format: int32
                           type: integer
-                      required:
-                        - host
-                        - port
                       type: object
                     eksClusterName:
                       description: |-
@@ -1049,7 +1046,9 @@
                             description: EnvVar represents an environment variable present in a Container.
                             properties:
                               name:
-                                description: Name of the environment variable. Must be a C_IDENTIFIER.
+                                description: |-
+                                  Name of the environment variable.
+                                  May consist of any printable ASCII characters except '='.
                                 type: string
                               value:
                                 description: |-
@@ -1101,6 +1100,42 @@
                                         type: string
                                     required:
                                       - fieldPath
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  fileKeyRef:
+                                    description: |-
+                                      FileKeyRef selects a key of the env file.
+                                      Requires the EnvFiles feature gate to be enabled.
+                                    properties:
+                                      key:
+                                        description: |-
+                                          The key within the env file. An invalid key will prevent the pod from starting.
+                                          The keys defined within a source may consist of any printable ASCII characters except '='.
+                                          During Alpha stage of the EnvFiles feature gate, the key size is limited to 128 characters.
+                                        type: string
+                                      optional:
+                                        default: false
+                                        description: |-
+                                          Specify whether the file or its key must be defined. If the file or key
+                                          does not exist, then the env var is not published.
+                                          If optional is set to true and the specified key does not exist,
+                                          the environment variable will not be set in the Pod's containers.
+
+                                          If optional is set to false and the specified key does not exist,
+                                          an error will be returned during Pod creation.
+                                        type: boolean
+                                      path:
+                                        description: |-
+                                          The path within the volume from which to select the file.
+                                          Must be relative and may not contain the '..' path or start with '..'.
+                                        type: string
+                                      volumeName:
+                                        description: The name of the volume mount containing the env file.
+                                        type: string
+                                    required:
+                                      - key
+                                      - path
+                                      - volumeName
                                     type: object
                                     x-kubernetes-map-type: atomic
                                   resourceFieldRef:

--- a/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/rosacontrolplanes.controlplane.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/controlplane/patches/versions/v1beta2/rosacontrolplanes.controlplane.cluster.x-k8s.io.yaml
@@ -187,9 +187,6 @@
                   description: port is the port on which the API server is serving.
                   format: int32
                   type: integer
-              required:
-                - host
-                - port
               type: object
             credentialsSecretRef:
               description: |-

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta1/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta1/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -74,9 +74,6 @@
                   description: port is the port on which the API server is serving.
                   format: int32
                   type: integer
-              required:
-                - host
-                - port
               type: object
             controlPlaneLoadBalancer:
               description: ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta1/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta1/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -104,9 +104,6 @@
                           description: port is the port on which the API server is serving.
                           format: int32
                           type: integer
-                      required:
-                        - host
-                        - port
                       type: object
                     controlPlaneLoadBalancer:
                       description: ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -75,9 +75,6 @@
                   description: port is the port on which the API server is serving.
                   format: int32
                   type: integer
-              required:
-                - host
-                - port
               type: object
             controlPlaneLoadBalancer:
               description: ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.
@@ -200,6 +197,15 @@
                     DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts
                     file of each instance. This is by default, false.
                   type: boolean
+                dnsResolutionCheck:
+                  description: |-
+                    DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
+                    Set to "None" to disable the check.
+                    If omitted, the provider will pick a reasonable default which may change over time.
+                  enum:
+                    - None
+                    - Enabled
+                  type: string
                 healthCheck:
                   description: HealthCheck sets custom health check configuration to the API target group.
                   properties:
@@ -1045,6 +1051,15 @@
                     DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts
                     file of each instance. This is by default, false.
                   type: boolean
+                dnsResolutionCheck:
+                  description: |-
+                    DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
+                    Set to "None" to disable the check.
+                    If omitted, the provider will pick a reasonable default which may change over time.
+                  enum:
+                    - None
+                    - Enabled
+                  type: string
                 healthCheck:
                   description: HealthCheck sets custom health check configuration to the API target group.
                   properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -105,9 +105,6 @@
                           description: port is the port on which the API server is serving.
                           format: int32
                           type: integer
-                      required:
-                        - host
-                        - port
                       type: object
                     controlPlaneLoadBalancer:
                       description: ControlPlaneLoadBalancer is optional configuration for customizing control plane behavior.
@@ -230,6 +227,15 @@
                             DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts
                             file of each instance. This is by default, false.
                           type: boolean
+                        dnsResolutionCheck:
+                          description: |-
+                            DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
+                            Set to "None" to disable the check.
+                            If omitted, the provider will pick a reasonable default which may change over time.
+                          enum:
+                            - None
+                            - Enabled
+                          type: string
                         healthCheck:
                           description: HealthCheck sets custom health check configuration to the API target group.
                           properties:
@@ -1075,6 +1081,15 @@
                             DisableHostsRewrite disabled the hair pinning issue solution that adds the NLB's address as 127.0.0.1 to the hosts
                             file of each instance. This is by default, false.
                           type: boolean
+                        dnsResolutionCheck:
+                          description: |-
+                            DNSResolutionCheck configures the behavior for checking the load balancer DNS resolution.
+                            Set to "None" to disable the check.
+                            If omitted, the provider will pick a reasonable default which may change over time.
+                          enum:
+                            - None
+                            - Enabled
+                          type: string
                         healthCheck:
                           description: HealthCheck sets custom health check configuration to the API target group.
                           properties:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmanagedclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmanagedclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -35,9 +35,6 @@
                   description: port is the port on which the API server is serving.
                   format: int32
                   type: integer
-              required:
-                - host
-                - port
               type: object
           type: object
         status:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmanagedclustertemplates.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/awsmanagedclustertemplates.infrastructure.cluster.x-k8s.io.yaml
@@ -41,9 +41,6 @@
                           description: port is the port on which the API server is serving.
                           format: int32
                           type: integer
-                      required:
-                        - host
-                        - port
                       type: object
                   type: object
               required:

--- a/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/rosaclusters.infrastructure.cluster.x-k8s.io.yaml
+++ b/helm/cluster-api-provider-aws/files/infrastructure/patches/versions/v1beta2/rosaclusters.infrastructure.cluster.x-k8s.io.yaml
@@ -35,9 +35,6 @@
                   description: port is the port on which the API server is serving.
                   format: int32
                   type: integer
-              required:
-                - host
-                - port
               type: object
           type: object
         status:

--- a/helm/cluster-api-provider-aws/values.yaml
+++ b/helm/cluster-api-provider-aws/values.yaml
@@ -12,8 +12,9 @@ name: cluster-api-provider-aws
 #   * Fix cluster upgrade version skew (https://github.com/giantswarm/cluster-api-provider-aws/pull/631)
 #   *   + extra commit 'Conditionally proceed if `isMachinePoolAllowedToUpgradeDueToControlPlaneVersionSkew` returns an error'
 #   * Ignore release drift while deleting MachinePool and AWSMachinePool (https://github.com/giantswarm/cluster-api-provider-aws/pull/652; prefer single commit on `release-2.11` branch or newer)
-#   * Revert "Changed dedicated host validation logic to require tenancy = host" (bug that was introduced upstream and hinders reconciliation) (https://github.com/giantswarm/cluster-api-provider-aws/pull/655, to be replaced by upstream https://github.com/giantswarm/cluster-api-provider-aws/pull/655)
-tag: v2.11.0-gs-dd3553695
+#   * Bump CAPI to v1.12.2, k8s to v1.34 and controller-runtime to v0.22.5 (backport of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/5857 *before* it was merged upstream)
+#   * Fix bug in "Changed dedicated host validation logic to require tenancy = host" (https://github.com/giantswarm/cluster-api-provider-aws/pull/655)
+tag: v2.11.0-gs-92c8b2e97
 
 registry:
   domain: gsoci.azurecr.io


### PR DESCRIPTION
Contains https://github.com/giantswarm/cluster-api-provider-aws/pull/656, towards https://github.com/giantswarm/roadmap/issues/4246

### Checklist

- [x] Update changelog in CHANGELOG.md.
